### PR TITLE
run behind docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.idea
+target
+logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM java:8
+MAINTAINER The Guardian
+
+RUN apt-get --yes update && apt-get --yes install \
+  ruby \
+  nginx

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # login.gutools
 
 Small application to login a user via pan-domain-auth and redirect them.
+
+## Usage in DEV
+This app runs on port 9000, as do many other apps (unless explicitly specified).
+Running it through Docker in DEV means you don't have to remember to use unique ports for each app and adjust your nginx config accordingly.
+
+Set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables then run `docker-compose up`.
+
+### NB for OSX:
+You'll need to add a line to `/etc/hosts` to route requests to the Docker VM:
+
+```sh
+sudo sh -c "echo \"$(docker-machine ip default) login.local.dev-gutools.co.uk\" >> /etc/hosts"
+```

--- a/conf/application.local.conf
+++ b/conf/application.local.conf
@@ -4,8 +4,4 @@ host = "https://login.local.dev-gutools.co.uk"
 
 pandomain {
   domain = "local.dev-gutools.co.uk"
-  aws = {
-    keyId = "${AWS_ACCESS_KEY_ID}"
-    secret = "${AWS_SECRET_ACCESS_KEY}"
-  }
 }

--- a/conf/application.local.conf
+++ b/conf/application.local.conf
@@ -4,4 +4,8 @@ host = "https://login.local.dev-gutools.co.uk"
 
 pandomain {
   domain = "local.dev-gutools.co.uk"
+  aws = {
+    keyId = "${AWS_ACCESS_KEY_ID}"
+    secret = "${AWS_SECRET_ACCESS_KEY}"
+  }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ logins:
   volumes:
     - ".:/code"
     - "../dev-nginx:/dev-nginx"
+    - "$HOME/.aws/:/root/.aws:ro"
   environment:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN
   entrypoint: /code/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+logins:
+  build: .
+  dockerfile: Dockerfile
+  ports:
+    - "80:80"
+    - "443:443"
+  volumes:
+    - ".:/code"
+    - "../dev-nginx:/dev-nginx"
+  environment:
+    AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
+  entrypoint: /code/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,4 @@ logins:
     - ".:/code"
     - "../dev-nginx:/dev-nginx"
     - "$HOME/.aws/:/root/.aws:ro"
-  environment:
-    AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
-    AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
-    AWS_SESSION_TOKEN: $AWS_SESSION_TOKEN
   entrypoint: /code/entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,4 +9,4 @@ cp ssl/* /etc/nginx/
 
 # run app
 cd /code
-./activator "~ run -Dconfig.resource=application.local.conf -Dpandomain.aws.keyId=$AWS_ACCESS_KEY_ID -Dpandomain.aws.secret=$AWS_SECRET_ACCESS_KEY"
+./start-login.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,9 @@
 cd /dev-nginx
 cp ssl/* /etc/nginx/
 ./setup-app.rb /code/nginx/nginx-mapping.yml
-./restart-nginx.sh
+
+# start nginx
+nginx
 
 # run app
 cd /code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# setup nginx
+# TODO don't do this every time the container starts?
+cd /dev-nginx
+cp ssl/* /etc/nginx/
+./setup-app.rb /code/nginx/nginx-mapping.yml
+./restart-nginx.sh
+
+# run app
+cd /code
+./activator "~ run -Dconfig.resource=application.local.conf -Dpandomain.aws.keyId=$AWS_ACCESS_KEY_ID -Dpandomain.aws.secret=$AWS_SECRET_ACCESS_KEY"

--- a/start-login.sh
+++ b/start-login.sh
@@ -1,1 +1,3 @@
-activator "run -Dconfig.resource=application.local.conf"
+#!/usr/bin/env bash
+
+./activator "~run -Dconfig.resource=application.local.conf"


### PR DESCRIPTION
Builds on https://github.com/guardian/login.gutools/pull/5.

This app runs on port 9000, as do many other apps (unless explicitly specified). Running it through Docker in DEV means you don't have to remember to use unique ports for each app and adjust your nginx config accordingly.

Usage: set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars then `docker-compose up`.

NB for OSX - add a line to `/etc/hosts` to make sure it goes to the correct destination (the VM Docker is running on).

``` sh
sudo sh -c "echo \"$(docker-machine ip default) login.local.dev-gutools.co.uk\" >> /etc/hosts"
```
