### PR TITLE
use credentials provider chain for aws auth

### DIFF
--- a/app/controllers/PanDomainAuthActions.scala
+++ b/app/controllers/PanDomainAuthActions.scala
@@ -21,14 +21,12 @@ trait PanDomainAuthActions extends AuthActions {
 
   override lazy val domain: String = LoginConfig.domain
 
-  def credentialsProviderChain = new AWSCredentialsProviderChain(
+  override lazy val awsCredentialsProvider = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),
     new SystemPropertiesCredentialsProvider(),
     new InstanceProfileCredentialsProvider(),
     new ProfileCredentialsProvider("workflow")
   )
-
-  override lazy val awsCredentials = Some(credentialsProviderChain.getCredentials)
 
   override lazy val system: String = "login"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   ws,
   specs2 % Test,
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.7",
-  "com.amazonaws" % "aws-java-sdk" % "1.7.5"
+  "com.amazonaws" % "aws-java-sdk" % "1.10.50"
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   cache,
   ws,
   specs2 % Test,
-  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.7",
+  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.11",
   "com.amazonaws" % "aws-java-sdk" % "1.10.50"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,16 @@ name := "login"
 
 version := "0.0.1"
 
+val awsSdkVersion = "1.10.50"
+
 libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
   specs2 % Test,
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.11",
-  "com.amazonaws" % "aws-java-sdk" % "1.10.50"
+  "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion
 )
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"


### PR DESCRIPTION
provides Janus support and instance profile authentication

Replaces https://github.com/guardian/login.gutools/pull/5 too.