### PR TITLE
Extends cookie if already signed in and emergency switch is on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # login.gutools
 
 Small application to login a user via pan-domain-auth and redirect them.
+
+## Running locally
+
+To run as to behave like production (uses `application.conf`) `./sbt run`
+
+To run in developer mode (pulls in `application.local.conf`) `./sbt devrun`
+
+To run in debug mode `./sbt --debug`

--- a/app/Global.scala
+++ b/app/Global.scala
@@ -1,0 +1,17 @@
+import config.LoginPublicSettings
+import play.Logger
+import play.api.{GlobalSettings, Application}
+
+object Global extends GlobalSettings {
+
+  override def onStart(app: Application) {
+    Logger.info("Application has started")
+    LoginPublicSettings.start
+  }
+
+  override def onStop(app: Application) {
+    LoginPublicSettings.stop
+    Logger.info("Application has shutdown...")
+  }
+
+}

--- a/app/actions/EmergencySwitchIsOnAction.scala
+++ b/app/actions/EmergencySwitchIsOnAction.scala
@@ -1,0 +1,17 @@
+package actions
+
+import play.api.mvc.Results._
+import play.api.mvc.{ActionBuilder, Request, Result}
+import play.api.Play.current
+import scala.concurrent.Future
+
+object EmergencySwitchIsOnAction extends ActionBuilder[Request]{
+  override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] = {
+    val emergencyReissueSwitchOption = play.api.Play.configuration.getString("emergency.reissue")
+    emergencyReissueSwitchOption match {
+      case Some("on") => block(request)
+      case Some("off") => Future.successful(SeeOther("/emergency/reissue-disabled"))
+      case _ => Future.successful(BadRequest("Emergency reissue config switch is not configured correctly, value must be 'on' or 'off'."))
+    }
+  }
+}

--- a/app/config/LoginPublicSettings.scala
+++ b/app/config/LoginPublicSettings.scala
@@ -1,0 +1,31 @@
+package config
+
+import com.gu.pandomainauth.PublicSettings
+import dispatch.Http
+import play.api.Logger
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object LoginPublicSettings {
+
+  private val loginConfig = LoginConfig.loginConfig(AWS.eC2Client)
+  private implicit val dispatchClient = Http
+
+  private val agent = new PublicSettings(loginConfig.domain)
+
+  def start = {
+    Logger.info("Starting LoginPublicSettings agent")
+    agent.start()
+  }
+
+  def stop = {
+    Logger.info("Stopping LoginPublicSettings agent")
+    agent.stop()
+  }
+
+  def publicKey = {
+    val key = agent.publicKey
+    if(key.isEmpty) Logger.error("Public key not available")
+    key
+  }
+
+}

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,8 +1,7 @@
 package controllers
 
-import java.util.Date
-
 import actions.EmergencySwitchIsOnAction
+import com.github.nscala_time.time.Imports._
 import com.gu.pandomainauth.PublicSettings
 import com.gu.pandomainauth.model.{CookieParseException, CookieSignatureInvalidException}
 import com.gu.pandomainauth.service.CookieUtils
@@ -10,11 +9,9 @@ import config.LoginPublicSettings
 import play.api.Logger
 import play.api.mvc.{Action, Controller}
 
-
 object Emergency extends Controller with PanDomainAuthActions {
 
-  //TODO - import library?
-  val cookieLifetime: Long = 1000 * 60 * 60 * 24 // 1 day
+  val cookieLifetime = 1.day
 
   def reissueDisabled = Action {
     Ok(views.html.emergency.reissueDisabled())
@@ -28,7 +25,7 @@ object Emergency extends Controller with PanDomainAuthActions {
       try {
         val authenticatedUser = CookieUtils.parseCookieData(assymCookie.value, publicKey)
         if (validateUser(authenticatedUser)) {
-          val expires = new Date().getTime + cookieLifetime
+          val expires = (DateTime.now() + cookieLifetime).getMillis
           val newAuthUser = authenticatedUser.copy(expires = expires)
           val authCookies = generateCookies(newAuthUser)
           Ok(views.html.emergency.reissueSuccess())

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import play.api.mvc.Controller
+
+object Emergency extends Controller with PanDomainAuthActions {
+
+  def reissue = {
+    //TODO:
+    /**
+      * Only allow this process to happen if a config switch is on
+      *
+      * Reads cookies from request
+      * Verifies the cookie
+      * Reads the data out of the cookie
+      * Creates a new cookie with same data
+      * Writes cookie to user's browser
+      *
+      *
+      */
+
+  }
+
+}

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -2,6 +2,7 @@ package controllers
 
 import java.util.Date
 
+import actions.EmergencySwitchIsOnAction
 import com.gu.pandomainauth.PublicSettings
 import com.gu.pandomainauth.model.{CookieParseException, CookieSignatureInvalidException}
 import com.gu.pandomainauth.service.CookieUtils
@@ -15,12 +16,11 @@ object Emergency extends Controller with PanDomainAuthActions {
   //TODO - import library?
   val cookieLifetime: Long = 1000 * 60 * 60 * 24 // 1 day
 
-  def reissue = Action { req =>
-    //TODO:
-    /**
-      * Only allow this process to happen if a config switch is on
-      *
-      */
+  def reissueDisabled = Action {
+    Ok(views.html.emergency.reissueDisabled())
+  }
+
+  def reissue = EmergencySwitchIsOnAction { req =>
     (for {
       publicKey <- LoginPublicSettings.publicKey
       assymCookie <- req.cookies.find(_.name == PublicSettings.assymCookieName)
@@ -48,7 +48,7 @@ object Emergency extends Controller with PanDomainAuthActions {
     }
   }
 
-  def unauthorised(message: String) = {
+  private def unauthorised(message: String) = {
     Logger.warn(message)
     Unauthorized(views.html.emergency.reissueFailure(message))
   }

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,23 +1,55 @@
 package controllers
 
-import play.api.mvc.Controller
+import java.util.Date
+
+import com.gu.pandomainauth.PublicSettings
+import com.gu.pandomainauth.model.{CookieParseException, CookieSignatureInvalidException}
+import com.gu.pandomainauth.service.CookieUtils
+import config.LoginPublicSettings
+import play.api.Logger
+import play.api.mvc.{Action, Controller}
+
 
 object Emergency extends Controller with PanDomainAuthActions {
 
-  def reissue = {
+  //TODO - import library?
+  val cookieLifetime: Long = 1000 * 60 * 60 * 24 // 1 day
+
+  def reissue = Action { req =>
     //TODO:
     /**
       * Only allow this process to happen if a config switch is on
       *
-      * Reads cookies from request
-      * Verifies the cookie
-      * Reads the data out of the cookie
-      * Creates a new cookie with same data
-      * Writes cookie to user's browser
-      *
-      *
       */
-
+    (for {
+      publicKey <- LoginPublicSettings.publicKey
+      assymCookie <- req.cookies.find(_.name == PublicSettings.assymCookieName)
+    } yield {
+      try {
+        val authenticatedUser = CookieUtils.parseCookieData(assymCookie.value, publicKey)
+        if (validateUser(authenticatedUser)) {
+          val expires = new Date().getTime + cookieLifetime
+          val newAuthUser = authenticatedUser.copy(expires = expires)
+          val authCookies = generateCookies(newAuthUser)
+          Ok(views.html.emergency.reissueSuccess())
+            .withCookies(authCookies: _*)
+        } else {
+          unauthorised("Only Guardian email addresses with two-factor auth are supported.")
+        }
+      }
+      catch {
+        case e: CookieSignatureInvalidException =>
+          unauthorised("Invalid existing session, could not log you in.")
+        case e: CookieParseException =>
+          unauthorised("Could not refresh existing session due to a corrupted cookie.")
+      }
+    }).getOrElse {
+      unauthorised("No existing login session found, unable to log you in.")
+    }
   }
 
+  def unauthorised(message: String) = {
+    Logger.warn(message)
+    Unauthorized(views.html.emergency.reissueFailure(message))
+  }
 }

--- a/app/views/emergency/reissueDisabled.scala.html
+++ b/app/views/emergency/reissueDisabled.scala.html
@@ -8,6 +8,6 @@
     <body>
         <h1>Reissue disabled</h1>
         <p>Extending login sessions is currently disabled.</p>
-        <p>If you are experiencing issues working with Editorial Tools please contact Central Production.</p>
+        <p>If you are experiencing issues working with Editorial Tools please contact Central Production (central.production@@theguardian.com).</p>
     </body>
 </html>

--- a/app/views/emergency/reissueDisabled.scala.html
+++ b/app/views/emergency/reissueDisabled.scala.html
@@ -1,0 +1,13 @@
+@()
+<html>
+    <head>
+        <title>
+            Reissue disabled
+        </title>
+    </head>
+    <body>
+        <h1>Reissue disabled</h1>
+        <p>Extending login sessions is currently disabled.</p>
+        <p>If are experiencing issues working with Editorial Tools please contact Central Production.</p>
+    </body>
+</html>

--- a/app/views/emergency/reissueDisabled.scala.html
+++ b/app/views/emergency/reissueDisabled.scala.html
@@ -8,6 +8,6 @@
     <body>
         <h1>Reissue disabled</h1>
         <p>Extending login sessions is currently disabled.</p>
-        <p>If are experiencing issues working with Editorial Tools please contact Central Production.</p>
+        <p>If you are experiencing issues working with Editorial Tools please contact Central Production.</p>
     </body>
 </html>

--- a/app/views/emergency/reissueFailure.scala.html
+++ b/app/views/emergency/reissueFailure.scala.html
@@ -1,0 +1,15 @@
+@(message: String)
+<html>
+    <head>
+        <title>
+            Failure
+        </title>
+    </head>
+    <body>
+        <h1>Your login session has not been extended.</h1>
+        <p>Please contact Central Production copying in the error message below. </p>
+
+
+        <h4>@message</h4>
+    </body>
+</html>

--- a/app/views/emergency/reissueFailure.scala.html
+++ b/app/views/emergency/reissueFailure.scala.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <h1>Your login session has not been extended.</h1>
-        <p>Please contact Central Production copying in the error message below. </p>
+        <p>Please contact Central Production (central.production@@theguardian.com) copying in the error message below. </p>
 
 
         <h4>@message</h4>

--- a/app/views/emergency/reissueSuccess.scala.html
+++ b/app/views/emergency/reissueSuccess.scala.html
@@ -9,6 +9,6 @@
         <h1>Your login session has been extended</h1>
 
         <p>You should be able to continue to use Editorial Tools. </p>
-        <p>If you are still experiencing issues working with Editorial Tools please contact Central Production.</p>
+        <p>If you are still experiencing issues working with Editorial Tools please contact Central Production (central.production@@theguardian.com).</p>
     </body>
 </html>

--- a/app/views/emergency/reissueSuccess.scala.html
+++ b/app/views/emergency/reissueSuccess.scala.html
@@ -9,6 +9,6 @@
         <h1>Your login session has been extended</h1>
 
         <p>You should be able to continue to use Editorial Tools. </p>
-        <p>If are still experiencing issues working with Editorial Tools please contact Central Production.</p>
+        <p>If you are still experiencing issues working with Editorial Tools please contact Central Production.</p>
     </body>
 </html>

--- a/app/views/emergency/reissueSuccess.scala.html
+++ b/app/views/emergency/reissueSuccess.scala.html
@@ -1,0 +1,14 @@
+@()
+<html>
+    <head>
+        <title>
+            Emergency reissue success
+        </title>
+    </head>
+    <body>
+        <h1>Your login session has been extended</h1>
+
+        <p>You should be able to continue to use Editorial Tools. </p>
+        <p>If are still experiencing issues working with Editorial Tools please contact Central Production.</p>
+    </body>
+</html>

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ libraryDependencies ++= Seq(
   jdbc,
   cache,
   ws,
-  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.12",
+  "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.13",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.github.nscala-time" %% "nscala-time" % "2.12.0",

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,8 @@ libraryDependencies ++= Seq(
 
 resolvers += "scalaz-bintray" at "http://dl.bintray.com/scalaz/releases"
 
+scalaVersion := "2.11.8"
+
 // Play provides two styles of routers, one expects its actions to be injected, the
 // other, legacy style, accesses its actions statically.
 //routesGenerator := InjectedRoutesGenerator

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "pan-domain-auth-play_2-4-0" % "0.2.12",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
+  "com.github.nscala-time" %% "nscala-time" % "2.12.0",
   "org.scalatest" %% "scalatest" % "2.2.6" % Test
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
 lazy val mainProject = project.in(file("."))
   .enablePlugins(PlayScala, RiffRaffArtifact)
   .settings(Defaults.coreDefaultSettings: _*)
+  .settings(addCommandAlias("devrun", "run -Dconfig.resource=application.local.conf 9000"): _*)
   .settings(
     // Never interested in the version number in the artifact name
     packageName in Universal := normalizedName.value,

--- a/conf/application.code.conf
+++ b/conf/application.code.conf
@@ -1,7 +1,0 @@
-include "application"
-
-host = "https://login.code.dev-gutools.co.uk"
-
-pandomain {
-  domain = "code.dev-gutools.co.uk"
-}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -46,3 +46,7 @@ play.i18n.langs = [ "en" ]
 pandomain {
   domain = "gutools.co.uk"
 }
+
+emergency {
+  reissue = "off"
+}

--- a/conf/application.local.conf
+++ b/conf/application.local.conf
@@ -5,3 +5,7 @@ host = "https://login.local.dev-gutools.co.uk"
 pandomain {
   domain = "local.dev-gutools.co.uk"
 }
+
+emergency {
+  reissue = "off"
+}

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -8,6 +8,19 @@
     </encoder>
   </appender>
 
+  <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>logs/login.gutools.log</file>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+      <fileNamePattern>logs/login.gutools.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+      <maxHistory>14</maxHistory>
+    </rollingPolicy>
+
+    <encoder>
+      <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{20}</pattern>
+    </encoder>
+  </appender>
+
   <!--
     The logger name is typically the Java/Scala package name.
     This configures the log level to log at for a package and its children packages.
@@ -15,8 +28,9 @@
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
 
-  <root level="ERROR">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
+    <appender-ref ref="LOGFILE" />
   </root>
 
 </configuration>

--- a/conf/routes
+++ b/conf/routes
@@ -8,6 +8,8 @@ GET     /showUser                   controllers.Login.status
 GET     /oauthCallback              controllers.Login.oauthCallback
 GET     /logout                     controllers.Login.logout
 
+GET     /emergency/reissue          controllers.Emergency.reissue
+
 GET     /_healthcheck               controllers.Application.healthCheck
 
 # Map static resources from the /public folder to the /assets URL path

--- a/conf/routes
+++ b/conf/routes
@@ -9,6 +9,7 @@ GET     /oauthCallback              controllers.Login.oauthCallback
 GET     /logout                     controllers.Login.logout
 
 GET     /emergency/reissue          controllers.Emergency.reissue
+GET     /emergency/reissue-disabled controllers.Emergency.reissueDisabled
 
 GET     /_healthcheck               controllers.Application.healthCheck
 


### PR DESCRIPTION
If Google auth is down we want to be able to extend the cookie lifetime for users already signed in.

This feature is behind a configuration switch. To turn this on this will require a config change and redeploy. A future PR will change this to work with polling from S3.

If the switch is ON the following steps are taken 
* The `assymCookieName` cookie is read from request
*  An authenticated user is parsed from the cookie data and verified that it is a valid user
*  A new cookie is issued with to the verified user with an extended cookie time which is sent to the user's browser.
* The user will be sent an error message and the cookie will not be extended if the switch is off, the user is not signed in, the cookie data could not be parsed or the user could not be verified. 

To do:
* ~~This requires an update on the pan-domain-authentication library to make use of `PublicSettings` `publicKey`: https://github.com/guardian/pan-domain-authentication/pull/27~~
* Check error and success messages make sense and are useful to the user.

cc @sihil @adamnfish 