### PR TITLE
Change log level of com.google.api.client.http.HttpTransport 

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -27,6 +27,7 @@
   -->
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
+  <logger name="com.google.api.client.http.HttpTransport" level="WARN" />
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
`com.google.api.client.http.HttpTransport` is noisy at INFO level so moving to WARN level.

cc/ @adamnfish 