### PR TITLE
Add a who-am-I endpoint

### DIFF
--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -17,4 +17,9 @@ object Login extends Controller with PanDomainAuthActions {
   def logout = Action { implicit request =>
     processLogout
   }
+
+  def whoami = APIAuthAction { request =>
+    val user = request.user
+    Ok(user.toJson)
+  }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -7,6 +7,7 @@ GET     /login                      controllers.Application.login(returnUrl: Str
 GET     /showUser                   controllers.Login.status
 GET     /oauthCallback              controllers.Login.oauthCallback
 GET     /logout                     controllers.Login.logout
+GET     /whoami                     controllers.Login.whoami
 
 GET     /emergency/reissue          controllers.Emergency.reissue
 GET     /emergency/reissue-disabled controllers.Emergency.reissueDisabled


### PR DESCRIPTION
It's extremely useful for serverless single page applications who want to know if the user is logged in and what's her email.

There's already an endpoint `/showUser` that is not exactly doing what it says, it simply returns `You are logged in` but has some iframe logic in it, so it didn't feel right to change it.

`/whoami` returns the JSON representation of the user or 401 if not logged in, which is what an API should do