### PR TITLE
Allow CORS for whoami

### DIFF
--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import model.Cors
 import play.api.mvc._
 
 
@@ -18,8 +19,8 @@ object Login extends Controller with PanDomainAuthActions {
     processLogout
   }
 
-  def whoami = APIAuthAction { request =>
+  def whoami = APIAuthAction { implicit request =>
     val user = request.user
-    Ok(user.toJson)
+    Cors(Ok(user.toJson).as("application/json"), Some("GET"))
   }
 }

--- a/app/model/Cors.scala
+++ b/app/model/Cors.scala
@@ -1,0 +1,28 @@
+package model
+
+import config.LoginConfig
+import play.api.Play.current
+import play.api.mvc.{RequestHeader, Result, Results}
+
+object Cors extends Results {
+
+  private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
+  lazy val pandaDomainOption = play.api.Play.configuration.getString("pandomain.domain")
+
+  def apply(result: Result, allowedMethods: Option[String] = None)(implicit request: RequestHeader): Result = {
+
+    val responseHeaders = (defaultAllowHeaders ++ request.headers.get("Access-Control-Request-Headers").toList) mkString ","
+
+    request.headers.get("Origin") match {
+      case None => result
+      case Some(requestOrigin) if LoginConfig.isValidUrl(pandaDomainOption, requestOrigin)  => {
+        val headers = allowedMethods.map("Access-Control-Allow-Methods" -> _).toList ++ List(
+          "Access-Control-Allow-Origin" -> requestOrigin,
+          "Access-Control-Allow-Headers" -> responseHeaders,
+          "Access-Control-Allow-Credentials" -> "true")
+        result.withHeaders(headers: _*)
+      }
+      case Some(requestOrigin) => Unauthorized
+    }
+  }
+}


### PR DESCRIPTION
A bit convoluted (scala experts might be able to do better).

/whoami is a APIAuthAction so it requires credentials, however you can't use '*' when credentials is true.
Your only option is to read the Origin request header, validate and forward it back

The checks make sure that you can only use CORS from a gutools, which I guess is a good thing (your cookie shouldn't be valid on another domain anyway)