### PR TITLE
don't include cloudformation in deploy

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -7,20 +7,11 @@
         "bucket": "composer-dist",
         "publicReadAcl": false
       }
-    },
-    "login-cloudformation" : {
-      "type": "cloud-formation",
-      "fileName": "cloudformation",
-      "data": {
-        "templatePath": "login-tool.json",
-        "cloudFormationStackName": "login-tool",
-        "prependStackToCloudFormationStackName": false
-      }
     }
   },
   "recipes": {
     "default": {
-      "depends": ["login-cloudformation", "artifactUploadOnly", "deployOnly"]
+      "depends": ["artifactUploadOnly", "deployOnly"]
     },
 
     "deployOnly": {
@@ -29,10 +20,6 @@
 
     "artifactUploadOnly": {
       "actionsBeforeApp": ["login.uploadArtifacts"]
-    },
-
-    "login-cloudformation": {
-      "actions": ["login-cloudformation.updateStack"]
     }
   }
 }


### PR DESCRIPTION
Remove updating cloudformation from deploy to allow for checking cloudformation updates in more detail and to bring the login tool more in line with other apps. @jennysivapalan 