### PR TITLE
change from email address to editorial.tools.dev as its verified in SES

### DIFF
--- a/app/config/LoginConfig.scala
+++ b/app/config/LoginConfig.scala
@@ -24,8 +24,10 @@ object LoginConfig {
     val tokensTableName = s"login.gutools-tokens-${stage.toUpperCase}"
     val emergencyAccessTableName = s"login.gutools-emergency-access-${stage.toUpperCase}"
     val tokenReissueUri = host + "/emergency/new-cookie/"
-    val emailSettings = Map("from" -> "digitalcms.bugs@guardian.co.uk",
-      "replyTo" -> "core.central.production@guardian.co.uk ")
+    val emailSettings = Map(
+      "from" -> "editorial.tools.dev@theguardian.com",
+      "replyTo" -> "core.central.production@guardian.co.uk "
+    )
 
    val switchBucket = "login-gutools-config"
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -15,4 +15,6 @@ class Application(deps: LoginControllerComponents) extends LoginController(deps)
   def healthCheck() = Action { implicit request =>
     Ok("Ok")
   }
+
+  def index() = Action { implicit request => Ok("A small application to login a user via pan-domain-auth and redirect them.")}
 }

--- a/app/utils/Mailer.scala
+++ b/app/utils/Mailer.scala
@@ -14,13 +14,13 @@ class SES(sesClient: AmazonSimpleEmailService, loginConfig: LoginConfig) {
          |<div>
          |  Hi,
          |  <p>
-         |    The Guardian's Editorial Tools are currently experiencing issues with Google Authentication and so we cannot authenticate your access to the Tools.
+         |    The Guardian's Editorial Tools are experiencing login issues. This is likely due to a Google issue (please refer to emails from Central Production). You must perform an additional step to login.
          |  </p>
          |  <p>
-         |    Click <a href=$uri$token>here</a> to obtain a new cookie to allow you to use them.
+         |    Click <a href=$uri$token>here</a> to login and continue using the Tools.
          |  </p>
          |  <p>
-         |    <strong>Do NOT share this email.</strong>
+         |    <strong>Do NOT share this email with others. The link is private and for your use only.</strong>
          |  </p>
          |</div>
        """.stripMargin

--- a/app/utils/Mailer.scala
+++ b/app/utils/Mailer.scala
@@ -9,16 +9,30 @@ class SES(sesClient: AmazonSimpleEmailService, loginConfig: LoginConfig) {
 
     val uri = loginConfig.tokenReissueUri
 
-    val emailBody = s"<div>Click <a href=$uri$token>here</a> here to obtain a new cookie</div>"
+    val emailBody =
+      s"""
+         |<div>
+         |  Hi,
+         |  <p>
+         |    The Guardian's Editorial Tools are currently experiencing issues with Google Authentication and so we cannot authenticate your access to the Tools.
+         |  </p>
+         |  <p>
+         |    Click <a href=$uri$token>here</a> to obtain a new cookie to allow you to use them.
+         |  </p>
+         |  <p>
+         |    <strong>Do NOT share this email.</strong>
+         |  </p>
+         |</div>
+       """.stripMargin
 
     sesClient.sendEmail(new SendEmailRequest()
       .withDestination(new Destination().withToAddresses(sendTo))
       .withMessage(new Message()
-        .withSubject(new Content("Gutools new cookie link"))
+        .withSubject(new Content("[emergency login] Guardian Editorial Tools - new cookie link"))
         .withBody(new Body().withHtml(new Content(emailBody)))
       )
-      .withSource(loginConfig.emailSettings.get("from").get)
-      .withReplyToAddresses(loginConfig.emailSettings.get("replyTo").get)
+      .withSource(loginConfig.emailSettings("from"))
+      .withReplyToAddresses(loginConfig.emailSettings("replyTo"))
     )
 
   }

--- a/conf/routes
+++ b/conf/routes
@@ -2,6 +2,8 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
+GET     /                           controllers.Application.index
+
 GET     /login                       controllers.Application.login(returnUrl: String)
 
 GET     /showUser                    controllers.Login.status


### PR DESCRIPTION
`digitalcms.bugs@guardian.co.uk` isn't DKIM verified and so messages being sent from it are not getting through. Use the updated team email to send emails from instead. This is the same email used within Preview too.

Also update email message to be more descriptive.

Example email:
![image](https://user-images.githubusercontent.com/836140/56579898-3abff000-65c9-11e9-9149-50caab876a4f.png)
