### PR TITLE
Log to central ELK plus hygiene

### DIFF
--- a/app/AppLoader.scala
+++ b/app/AppLoader.scala
@@ -2,7 +2,6 @@ import play.api.{Application, ApplicationLoader, LoggerConfigurator}
 
 class AppLoader extends ApplicationLoader {
   override def load(context: ApplicationLoader.Context): Application = {
-    // TODO MRB: kinesis logging?
     LoggerConfigurator(context.environment.classLoader)
       .foreach(_.configure(context.environment))
 

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -3,39 +3,39 @@ package config
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, SystemPropertiesCredentialsProvider}
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.autoscaling.AmazonAutoScalingClientBuilder
+import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
 import com.amazonaws.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, DescribeAutoScalingInstancesRequest}
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClientBuilder
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.simpleemail.{AmazonSimpleEmailService, AmazonSimpleEmailServiceClientBuilder}
+import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
 import com.amazonaws.util.EC2MetadataUtils
 
 import scala.collection.JavaConverters._
 
 case class InstanceTags(stack: String, app: String, stage: String)
 
-object AWS {
-  lazy val region = Region.getRegion(Regions.EU_WEST_1).getName
-  lazy val workflowAwsCredentialsProvider = new AWSCredentialsProviderChain(
+class AWS {
+  val region = Region.getRegion(Regions.EU_WEST_1).getName
+  val workflowAwsCredentialsProvider = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),
     new SystemPropertiesCredentialsProvider(),
     InstanceProfileCredentialsProvider.getInstance(),
     new ProfileCredentialsProvider("workflow")
   )
-  lazy val composerAwsCredentialsProvider = new AWSCredentialsProviderChain(
+  val composerAwsCredentialsProvider = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),
     new SystemPropertiesCredentialsProvider(),
     InstanceProfileCredentialsProvider.getInstance(),
     new ProfileCredentialsProvider("composer")
   )
 
-  lazy val asgClient = AmazonAutoScalingClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
-  lazy val ssmClient = AWSSimpleSystemsManagementClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
+  val asgClient: AmazonAutoScaling = AmazonAutoScalingClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
+  val ssmClient: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
 
-  lazy val s3Client = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
-  lazy val sesClient = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
-  lazy val dynamoDbClient = AmazonDynamoDBClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
+  val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
+  val sesClient: AmazonSimpleEmailService = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
+  val dynamoDbClient: AmazonDynamoDB = AmazonDynamoDBClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
 
   def readTags(): Option[InstanceTags] = {
     // We read tags from the AutoScalingGroup rather than the instance itself to avoid problems where the

--- a/app/config/LoginConfig.scala
+++ b/app/config/LoginConfig.scala
@@ -2,14 +2,12 @@ package config
 
 import java.net.URL
 
-import com.amazonaws.services.ec2.AmazonEC2Client
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClient
-
 import scala.util.control.NonFatal
 
 
 case class LoginConfig(stage: String, domain: String, host: String, appName: String, emergencyAccessTableName: String,
-                       tokensTableName: String, tokenReissueUri: String, emailSettings: Map[String, String], switchBucket: String)
+                       tokensTableName: String, tokenReissueUri: String, emailSettings: Map[String, String],
+                       switchBucket: String, loggingStream: Option[String])
 
 object LoginConfig {
  def forStage(stageOpt: Option[String]): LoginConfig = {
@@ -28,10 +26,15 @@ object LoginConfig {
       "from" -> "editorial.tools.dev@theguardian.com",
       "replyTo" -> "core.central.production@guardian.co.uk "
     )
+    val loggingStream = stage match {
+      case "DEV" => None
+      case _ => Some("elk-PROD-KinesisStream-1PYU4KS1UEQA")
+    }
 
    val switchBucket = "login-gutools-config"
 
-    LoginConfig(stage, domain, host, appName, emergencyAccessTableName, tokensTableName, tokenReissueUri, emailSettings, switchBucket)
+    LoginConfig(stage, domain, host, appName, emergencyAccessTableName, tokensTableName, tokenReissueUri,
+      emailSettings, switchBucket, loggingStream)
   }
 
   /**

--- a/app/config/LoginPublicSettings.scala
+++ b/app/config/LoginPublicSettings.scala
@@ -2,26 +2,26 @@ package config
 
 import com.gu.pandomainauth.PublicSettings
 import okhttp3.OkHttpClient
-import play.api.Logger
+import utils.Loggable
 
 import scala.concurrent.ExecutionContext
 
-class LoginPublicSettings(config: LoginConfig)(implicit ec: ExecutionContext) {
+class LoginPublicSettings(config: LoginConfig)(implicit ec: ExecutionContext) extends Loggable {
   private val agent = new PublicSettings(config.domain)(new OkHttpClient(), ec)
 
   def start = {
-    Logger.info("Starting LoginPublicSettings agent")
+    log.info("Starting LoginPublicSettings agent")
     agent.start()
   }
 
   def stop = {
-    Logger.info("Stopping LoginPublicSettings agent")
+    log.info("Stopping LoginPublicSettings agent")
     agent.stop()
   }
 
   def publicKey = {
     val key = agent.publicKey
-    if(key.isEmpty) Logger.error("Public key not available")
+    if(key.isEmpty) log.error("Public key not available")
     key
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,9 +1,12 @@
 package controllers
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import config.LoginConfig
 
 
-class Application(deps: LoginControllerComponents) extends LoginController(deps) {
+class Application(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB)
+  extends LoginController(deps, dynamoDbClient) {
+
   def login(returnUrl: String) = AuthAction { implicit request =>
     if (LoginConfig.isValidUrl(config.domain, returnUrl)) {
       Redirect(returnUrl)

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,11 +1,10 @@
 package controllers
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import config.LoginConfig
-import play.api.Configuration
 import play.api.mvc._
 
-
-class Login(deps: LoginControllerComponents) extends LoginController(deps) {
+class Login(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB) extends LoginController(deps, dynamoDbClient) {
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
   def oauthCallback = Action.async { implicit request =>

--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -1,9 +1,9 @@
 package controllers
 
-import config.{Off, On, SwitchState, Switches}
-import play.api.mvc.{BaseController, ControllerComponents}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import config.{Off, On, SwitchState}
 
-class SwitchesController(deps: LoginControllerComponents) extends LoginController(deps) {
+class SwitchesController(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB) extends LoginController(deps, dynamoDbClient) {
 
   private def errorMessage(state: SwitchState)  = s"Failed to update Emergency switch to ${state.name}. Contact digitalcms.dev@theguardian.com for more help."
   private def success(state: SwitchState)  = s"Emergency switch updated to ${state.name}"

--- a/app/utils/ElkLogging.scala
+++ b/app/utils/ElkLogging.scala
@@ -1,0 +1,107 @@
+package utils
+
+import ch.qos.logback.classic.{AsyncAppender, Logger, LoggerContext}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.Appender
+import ch.qos.logback.core.joran.spi.JoranException
+import ch.qos.logback.core.util.StatusPrinter
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.gu.logback.appender.kinesis.KinesisAppender
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
+import play.api.inject.ApplicationLifecycle
+import play.api.libs.json.{Json => PlayJson}
+import login.BuildInfo
+
+import scala.util.control.NonFatal
+
+class ElkLogging(stage: String,
+                 region: String,
+                 loggingStreamName: Option[String],
+                 awsCredentialsProvider: AWSCredentialsProvider,
+                 applicationLifecycle: ApplicationLifecycle) extends Loggable {
+  def getContextTags: Map[String, String] = {
+    val effective = Map(
+      "app" -> "login",
+      "stage" -> stage,
+      "stack" -> "flexible",
+      "region" -> region,
+      "buildNumber" -> BuildInfo.buildNumber
+    )
+    log.info(s"Logging with context map: $effective")
+    effective
+  }
+
+  // initialise immediately, but ensure we don't blow anything up if we fail
+  try {
+    init()
+  } catch {
+    case NonFatal(e) => log.error("Failed to initialise log shipping", e)
+  }
+
+  def makeCustomFields(customFields: Map[String, String]): String = {
+    PlayJson.stringify(PlayJson.toJson(customFields))
+  }
+
+  private def makeLayout(customFields: String) = {
+    val l = new LogstashLayout()
+    l.setCustomFields(customFields)
+    l
+  }
+
+  private def makeKinesisAppender(layout: LogstashLayout, context: LoggerContext, streamName: String, bufferSize: Int): KinesisAppender[ILoggingEvent] = {
+    val a = new KinesisAppender[ILoggingEvent]()
+    a.setStreamName(streamName)
+    a.setRegion(region)
+    a.setCredentialsProvider(awsCredentialsProvider)
+    a.setBufferSize(bufferSize)
+
+    a.setContext(context)
+    a.setLayout(layout)
+
+    layout.start()
+    a.start()
+    a
+  }
+
+  private def wrapWithAsyncAppender(context: LoggerContext, appender: Appender[ILoggingEvent], bufferSize: Int): AsyncAppender = {
+    val a = new AsyncAppender()
+    a.addAppender(appender)
+    a.setNeverBlock(true)
+    a.setQueueSize(bufferSize)
+    a.setIncludeCallerData(true)
+    a.setContext(context)
+    a.start()
+    a
+  }
+
+  // assume SLF4J is bound to logback in the current environment
+  private def getLoggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+
+  private def getRootLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[Logger]
+
+  def init() {
+    val maybeStreamName = loggingStreamName
+
+    if (maybeStreamName.isEmpty) log.info("Not configuring log shipping as stream not configured")
+
+    val bufferSize = 1000
+
+    maybeStreamName.foreach { streamName =>
+      log.info("Configuring logging to ship to ELK")
+
+      try {
+        val layout = makeLayout(makeCustomFields(getContextTags))
+        val appender = makeKinesisAppender(layout, getLoggerContext, streamName, bufferSize)
+        val asyncAppender = wrapWithAsyncAppender(getLoggerContext, appender, bufferSize)
+        val rootLogger = getRootLogger
+        rootLogger.addAppender(asyncAppender)
+      } catch {
+        case e: JoranException => // ignore, errors will be printed below
+      }
+
+      StatusPrinter.printInCaseOfErrorsOrWarnings(getLoggerContext)
+      log.info("Log shipping configuration completed")
+    }
+  }
+}

--- a/app/utils/Loggable.scala
+++ b/app/utils/Loggable.scala
@@ -1,0 +1,7 @@
+package utils
+
+import org.slf4j.{Logger, LoggerFactory}
+
+trait Loggable {
+  protected lazy val log: Logger = LoggerFactory.getLogger(getClass)
+}

--- a/app/utils/Mailer.scala
+++ b/app/utils/Mailer.scala
@@ -1,4 +1,4 @@
-package mailer
+package utils
 
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
 import com.amazonaws.services.simpleemail.model._

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.1
+sbt.version=1.2.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,4 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
This PR adds central ELK logging to this project. In addition I did a little hygiene as I went along including:
 - eliminating the global AWS object
 - switching from play Logger to making `log` available from a trait
 - adding `sbt-buildinfo` so we can track the code release from the logs
 - bumping AWS SDK