### PR TITLE
Fix deployment issues with login.gutools

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -6,7 +6,7 @@ import router.Routes
 import scala.concurrent.Future
 
 class AppComponents(context: Context) extends LoginControllerComponents(context) {
-  override val config = LoginConfig.forStage(instanceTags.map(_.stage))
+  override val config = LoginConfig.forStage(asgTags.map(_.stage))
   override val switches = new Switches(config)
 
   val loginPublicSettings = new LoginPublicSettings(config)

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -7,8 +7,8 @@ import com.github.t3hnar.bcrypt._
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
-import com.gu.play.secretrotation.aws.ParameterStore
-import com.gu.play.secretrotation.{RotatingSecretComponents, SecretState, TransitionTiming}
+import com.gu.play.secretrotation._
+import com.gu.play.secretrotation.aws.parameterstore.AwsSdkV1
 import com.gu.scanamo._
 import com.gu.scanamo.syntax._
 import config._
@@ -37,10 +37,12 @@ abstract class LoginControllerComponents(context: Context) extends BuiltInCompon
     val app = asgTags.map(_.app).getOrElse("login")
     val stage = asgTags.map(_.stack).getOrElse("DEV")
 
-    new ParameterStore.SecretSupplier(
+    import aws.parameterstore
+
+    new parameterstore.SecretSupplier(
       TransitionTiming(usageDelay = Duration.ofMinutes(3), overlapDuration = Duration.ofHours(2)),
       parameterName = s"/$stack/$app/$stage/play.http.secret.key",
-      AWS.ssmClient
+      AwsSdkV1(AWS.ssmClient)
     )
   }
 }

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -35,7 +35,7 @@ abstract class LoginControllerComponents(context: Context) extends BuiltInCompon
   override lazy val secretStateSupplier: SnapshotProvider = {
     val stack = asgTags.map(_.stack).getOrElse("flexible")
     val app = asgTags.map(_.app).getOrElse("login")
-    val stage = asgTags.map(_.stack).getOrElse("DEV")
+    val stage = asgTags.map(_.stage).getOrElse("DEV")
 
     import aws.parameterstore
 

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import java.time.Duration
-import java.util.function.Supplier
 
 import com.github.t3hnar.bcrypt._
 import com.gu.pandomainauth.action.AuthActions
@@ -17,12 +16,16 @@ import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc._
 import play.api.{BuiltInComponentsFromContext, Logger}
-import play.filters.HttpFiltersComponents
+import play.filters.csrf.CSRFComponents
+import play.filters.headers.SecurityHeadersComponents
 
 import scala.concurrent.{ExecutionContext, Future}
 
 abstract class LoginControllerComponents(context: Context) extends BuiltInComponentsFromContext(context)
-  with AhcWSComponents with AssetsComponents with HttpFiltersComponents with RotatingSecretComponents {
+  with AhcWSComponents with AssetsComponents with CSRFComponents
+  with SecurityHeadersComponents with RotatingSecretComponents {
+
+  def httpFilters: Seq[EssentialFilter] = Seq(csrfFilter, securityHeadersFilter)
 
   def config: LoginConfig
   def switches: Switches

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -27,15 +27,15 @@ abstract class LoginControllerComponents(context: Context) extends BuiltInCompon
   def config: LoginConfig
   def switches: Switches
 
-  lazy val instanceTags: Option[InstanceTags] = AWS.readTags()
+  lazy val asgTags: Option[InstanceTags] = AWS.readTags()
 
   lazy val panDomainSettings: PanDomainAuthSettingsRefresher =
     new PanDomainAuthSettingsRefresher(config.domain, "login", actorSystem, AWS.workflowAwsCredentialsProvider)
 
-  override lazy val secretStateSupplier: Supplier[SecretState] = {
-    val stack = instanceTags.map(_.stack).getOrElse("flexible")
-    val app = instanceTags.map(_.app).getOrElse("login")
-    val stage = instanceTags.map(_.stack).getOrElse("DEV")
+  override lazy val secretStateSupplier: SnapshotProvider = {
+    val stack = asgTags.map(_.stack).getOrElse("flexible")
+    val app = asgTags.map(_.app).getOrElse("login")
+    val stage = asgTags.map(_.stack).getOrElse("DEV")
 
     new ParameterStore.SecretSupplier(
       TransitionTiming(usageDelay = Duration.ofMinutes(3), overlapDuration = Duration.ofHours(2)),

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   jdbc,
   ws,
   "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.0",
-  "com.gu.play-secret-rotation" %% "aws-parameterstore" % "0.7",
+  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.14",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,

--- a/conf/routes
+++ b/conf/routes
@@ -15,9 +15,12 @@ GET     /emergency/reissue           controllers.Emergency.reissue
 GET     /emergency/reissue-disabled  controllers.Emergency.reissueDisabled
 GET     /emergency/request-cookie    controllers.Emergency.requestCookieLink
 GET     /emergency/new-cookie/:token controllers.Emergency.issueNewCookie(token)
++ NOCSRF
 POST    /emergency/send-cookie-link  controllers.Emergency.sendCookieLink
 
++ NOCSRF
 POST    /switches/emergency/on       controllers.SwitchesController.emergencyOn
++ NOCSRF
 POST    /switches/emergency/off      controllers.SwitchesController.emergencyOff
 GET     /switches                    controllers.SwitchesController.index
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.12")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.17")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -12,9 +12,6 @@ deployments:
         Recipe: editorial-tools-xenial-java8
         BuiltBy: amigo
       amiEncrypted: true
-      cloudFormationStackByTags: false
-      prependStackToCloudFormationStackName: false
-      cloudFormationStackName: login-tool
   login:
     type: autoscaling
     parameters:


### PR DESCRIPTION
We've not been deploying login.gutools for 14 months 😢 but this fixes it and bumps play-secret-rotation as well.

See CFN changes at https://github.com/guardian/editorial-tools-platform/pull/294