### PR TITLE
Use Composer profile to reach the pan-domain-auth-settings bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Small application to login a user via pan-domain-auth and redirect them.
 
 ## Running locally
-1. Get credentials for `composer` and `workflow` from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=composer-dev,workflow-dev&tzOffset=1).
+1. Get credentials for `composer` from [Janus](https://janus.gutools.co.uk/multi-credentials?&permissionIds=composer-dev&tzOffset=1).
 1. Run `./script/setup`.
 1. Run `./script/start`.
 1. Open `https://login.local.dev-gutools.co.uk`.

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -17,12 +17,7 @@ case class InstanceTags(stack: String, app: String, stage: String)
 
 class AWS {
   val region = Region.getRegion(Regions.EU_WEST_1).getName
-  val workflowAwsCredentialsProvider = new AWSCredentialsProviderChain(
-    new EnvironmentVariableCredentialsProvider(),
-    new SystemPropertiesCredentialsProvider(),
-    InstanceProfileCredentialsProvider.getInstance(),
-    new ProfileCredentialsProvider("workflow")
-  )
+
   val composerAwsCredentialsProvider = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),
     new SystemPropertiesCredentialsProvider(),

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -35,7 +35,7 @@ abstract class LoginControllerComponents(context: Context, val aws: AWS) extends
   lazy val asgTags: Option[InstanceTags] = aws.readTags()
 
   lazy val panDomainSettings: PanDomainAuthSettingsRefresher =
-    new PanDomainAuthSettingsRefresher(config.domain, "login", actorSystem, aws.workflowAwsCredentialsProvider)
+    new PanDomainAuthSettingsRefresher(config.domain, "login", actorSystem, aws.composerAwsCredentialsProvider)
 
   override lazy val secretStateSupplier: SnapshotProvider = {
     val stack = asgTags.map(_.stack).getOrElse("flexible")


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The pan-domain-auth-settings bucket has a policy which allows each of the Tools accounts to GetObject. This means we can use Composer credentials to access the required files to validate a cookie. That is, we can simplify the requirements of this app to a single set of Janus credentials, rather than two.

This also relates to https://github.com/guardian/janus/pull/2407 and https://github.com/guardian/janus/pull/2401 which create a new Janus role with access to the specific resources needed to run this app.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Checkout branch
- Get Composer Janus credentials
- Run app
- Visit `https://login.local.dev-gutools.co.uk/logout` route to force a logout (or delete the cookie)
- Visit `https://login.local.dev-gutools.co.uk/whoami` and witness a 401 to confirm you do not have a valid cookie
- Visit `https://login.local.dev-gutools.co.uk/login?returnUrl=https://login.local.dev-gutools.co.uk/whoami` and witness a response to show you now have a cookie.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simpler setup instructions and fewer credentials needed.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

n/a