### PR TITLE
Script to fish for emergency login links if Gmail is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ To turn a switch on or off run:
 curl -X POST 'https://[login-domain]/switches/emergency/[on|off]' -k -H 'Authorization: Basic [firstname.lastname]@guardian.co.uk:[password]'
 ```
 
+In the event that Gmail is also down and users can't receive emails, you can fish out a login token to send to them by other means.
+You will need `composer` Janus credentials to run this script. Once they have visited the `/emergency/request-cookie` endpoint:
+
+```
+./script/get-emergency-login-link firstname.lastname@guardian.co.uk
+```
+

--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ You will need `composer` Janus credentials to run this script. Once they have vi
 ./script/get-emergency-login-link firstname.lastname@guardian.co.uk
 ```
 
+Be careful when sharing the link using WhatsApp etc. They will ping the link to build a preview unless it is sent in
+quotes which will use up the token and require the user to request another one.

--- a/script/get-emergency-login-link
+++ b/script/get-emergency-login-link
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e
+
+STAGE=${STAGE-PROD}
+EMAIL=${1}
+
+common_aws_args="--profile composer --region eu-west-1"
+
+login_gutools_instance="https://login.gutools.co.uk"
+token_table="login.gutools-tokens-PROD"
+
+if [ "${STAGE}" = "CODE" ]; then
+  login_gutools_instance="https://login.code.dev-gutools.co.uk"
+  token_table="login.gutools-tokens-CODE"
+elif [ "${STAGE}" = "DEV" ]; then
+  login_gutools_instance="https://login.local.dev-gutools.co.uk"
+  token_table="login.gutools-tokens-DEV"
+fi
+
+request_cookie_link="${login_gutools_instance}/emergency/request-cookie"
+issue_cookie_link="${login_gutools_instance}/emergency/new-cookie"
+
+if [ -z "${EMAIL}" ]; then
+  echo "Usage: ./get-emergency-login-link <email address>"
+  echo "The user must have requested a cookie first at ${request_cookie_link}"
+  echo "To use in CODE or DEV: STAGE=[CODE|DEV] ./get-emergency-login-link <email address>"
+  exit 1
+fi
+
+scan_response=$(
+  aws dynamodb scan \
+    --table-name "${token_table}" \
+    --filter-expression 'email = :email' \
+    --expression-attribute-values "{ \":email\": { \"S\": \"${EMAIL}\"} }" \
+    ${common_aws_args}
+)
+
+token=$(
+  echo $scan_response | jq -r '.Items | map(select(.used.BOOL == false)) | sort_by(.requested.N) | last | .id.S'
+)
+
+if [ "${token}" = "null" ]; then
+  echo "Can't find token for user. Make sure they have requested a cookie first from ${request_cookie_link}"
+  exit 1
+fi
+
+echo "${issue_cookie_link}/${token}"

--- a/script/get-emergency-login-link
+++ b/script/get-emergency-login-link
@@ -45,4 +45,5 @@ if [ "${token}" = "null" ]; then
   exit 1
 fi
 
-echo "${issue_cookie_link}/${token}"
+# Wrap the link in quotes to try and stop WhatsApp et al pinging it to make a preview, using up the token
+echo "\"${issue_cookie_link}/${token}\""


### PR DESCRIPTION
The [Google outage of 14/12/20](https://www.theguardian.com/technology/2020/dec/14/google-suffers-worldwide-outage-with-gmail-youtube-and-other-services-down) also took down Gmail. This meant that users could extend their existing panda sessions but couldn't request new ones.

Providing the [emergency login switch is on](https://github.com/guardian/login.gutools#emergency-access-when-google-auth-is-down), to request a new session the user visits login.gutools.co.uk/emergency/request-cookie, types in their email address and we email them a token-based link. Once they click that we generate a new cookie for them. This naturally requires Gmail to be up and available to the user.

This PR adds a script that can be used by anyone with developer-level Composer Janus access to fish for the login token generated, so it can then be sent to the user via other means.

```
./script/get-emergency-login-link michael.barton@guardian.co.uk
"https://login.gutools.co.uk/emergency/new-cookie/<token>"
```

NB we wrap the link in quotes as WhatsApp tries to be useful and hits the URL whilst you compose the message to generate a preview, thus burning the token which is single use. If anyone knows a way to detect this and reject the request, it would be good to add that as a separate PR (I suspect user agent?). Otherwise we could add an additional button press for the user before dropping the cookie.