### PR TITLE
Add /decode endpoint that allows a cookie to be decoded

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -29,6 +29,7 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
   val emergency = new Emergency(loginPublicSettings, this, aws.dynamoDbClient, aws.sesClient)
   val login = new Login(this, aws.dynamoDbClient)
   val switchesController = new SwitchesController(this, aws.dynamoDbClient)
+  val cookieInfo = new CookieInfo(this, aws.dynamoDbClient)
 
-  override lazy val router = new Routes(httpErrorHandler, app, login, emergency, switchesController, assets)
+  override lazy val router = new Routes(httpErrorHandler, app, login, emergency, cookieInfo, switchesController, assets)
 }

--- a/app/controllers/CookieInfo.scala
+++ b/app/controllers/CookieInfo.scala
@@ -1,0 +1,92 @@
+package controllers
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.gu.pandomainauth.PanDomain
+import com.gu.pandomainauth.model.{Authenticated, AuthenticatedUser, AuthenticationStatus, Expired, GracePeriod, InvalidCookie, NotAuthenticated, NotAuthorized, User}
+import com.gu.pandomainauth.service.CookieUtils
+import org.apache.commons.codec.binary.Base64
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+import play.filters.csrf.CSRF
+import utils.Loggable
+
+import scala.util.{Success, Try}
+
+trait DecodedCookie
+case object NoCookie extends DecodedCookie
+case class BadCookie(reason: String, jsonOrRawCookieData: Either[String, AuthenticatedUser], e: Exception) extends DecodedCookie
+case class ValidCookie(validity: String, user: AuthenticatedUser) extends DecodedCookie
+
+class CookieInfo(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB)
+  extends LoginController(deps, dynamoDbClient) with Loggable {
+
+  def decodeForm = AuthAction { request =>
+    Ok(views.html.cookieInfo.submitCookie(request))
+  }
+
+  def decodeCookie = AuthAction(parse.formUrlEncoded) { request =>
+    val maybeCookie = request.body.get("cookie").flatMap(_.headOption)
+    maybeCookie
+      .map(trimCookie)
+      .fold[Result](BadRequest){ cookie =>
+        val authStatus = decodePandaCookie(cookie)
+        Ok(views.html.cookieInfo.cookieResult(authStatus))
+      }
+  }
+
+  private def decodePandaCookie(cookie: String): DecodedCookie = {
+    PanDomain.authStatus(cookie, panDomainSettings.settings.publicKey) match {
+      case InvalidCookie(exception) =>
+        cookie match {
+          case CookieUtils.CookieRegEx(b64data, b64sig) =>
+            val data = new String(Base64.decodeBase64(b64data.getBytes("UTF-8")))
+            log.info(data)
+            Try(deserializeAuthenticatedUser(data)) match {
+              case Success(authedUser) =>
+                BadCookie(
+                  "Signature invalid",
+                  Right(authedUser),
+                  exception
+                )
+              case _ =>
+                BadCookie(
+                  "User data not formatted correctly",
+                  Left(data),
+                  exception
+                )
+            }
+          case other => BadCookie("Not in <data>.<signature> format", Left(other), exception)
+        }
+      case NotAuthenticated => NoCookie
+      case Authenticated(authedUser) => ValidCookie("Authenticated", authedUser)
+      case Expired(authedUser) => ValidCookie("Expired", authedUser)
+      case GracePeriod(authedUser) => ValidCookie("Grace period", authedUser)
+      case NotAuthorized(authedUser) => ValidCookie("Not authorized", authedUser)
+    }
+  }
+
+  /** this is copied from CookieUtils as it is private there so we can deserialise
+    * cookies even when they have bad signatures */
+  private def deserializeAuthenticatedUser(serializedForm: String): AuthenticatedUser = {
+    val data = serializedForm
+      .split("&")
+      .map(_.split("=", 2))
+      .map{p => p(0) -> p(1)}
+      .toMap
+
+    AuthenticatedUser(
+      user = User(data("firstName"), data("lastName"), data("email"), data.get("avatarUrl")),
+      authenticatingSystem = data("system"),
+      authenticatedIn = Set(data("authedIn").split(",") :_*),
+      expires = data("expires").toLong,
+      multiFactor = data("multifactor").toBoolean
+    )
+  }
+
+  private def trimCookie(cookie: String): String = {
+    val initialTrim = cookie.trim
+    if (initialTrim.contains(" ")) {
+      initialTrim.split(" ").last.trim
+    } else initialTrim
+  }
+}

--- a/app/views/cookieInfo/cookieResult.scala.html
+++ b/app/views/cookieInfo/cookieResult.scala.html
@@ -1,0 +1,45 @@
+@(decodedCookie: DecodedCookie)
+<html>
+    <head>
+        <title>
+        Decoded cookie
+        </title>
+    </head>
+    <body>
+        <h1>Decoded cookie</h1>
+        @decodedCookie match {
+            case BadCookie(reason, data, exception) => {
+                <h2>Invalid cookie</h2>
+                <p>The cookie is not valid, either it is not the right shape or the signature on the cookie is invalid (using a different key pair to this instance of login - which likely means that it is from a different environment i.e. the wrong one of PROD/CODE).</p>
+                <h3>Failure reason: @reason</h3>
+                <div>
+                    @data match {
+                        case Right(user) => {
+                            <h3>Extracted user data from invalid cookie</h3>
+                            @views.html.cookieInfo.userSnippet(user)
+                        }
+                        case Left(rawData) => {
+                            <h3>Raw data (after base 64 decoding if successful)</h3>
+                            <pre>@rawData</pre>
+                        }
+                    }
+
+                    <h3>Panda library exception:</h3>
+                    <pre class="error"><span class="line">-></span><span class="code">@exception.getClass.getName: @exception.getMessage</span></pre>
+
+                    @exception.getStackTrace.map { line =>
+                        <pre><span class="line">&nbsp;</span><span class="code">    @line</span></pre>
+                    }
+                </div>
+            }
+            case NoCookie => {
+                <h2>No cookie found</h2>
+                <p>No cookie data?</p>
+            }
+            case ValidCookie(validity, user) => {
+                <h2>Cookie status: @validity</h2>
+                @views.html.cookieInfo.userSnippet(user)
+            }
+        }
+    </body>
+</html>

--- a/app/views/cookieInfo/submitCookie.scala.html
+++ b/app/views/cookieInfo/submitCookie.scala.html
@@ -1,0 +1,30 @@
+@import views.html.helper.CSRF
+@(implicit requestHeader: RequestHeader)
+<html>
+    <head>
+        <title>
+        Cookie info request
+        </title>
+    </head>
+    <body>
+        <h1>Paste in a pan domain assym cookie for validation and decoding</h1>
+
+        <div>Cookie should be copied from a browser session.</div>
+
+        <div>
+            <form action="/decode" method="post">
+                @CSRF.formField
+                <div>
+                    <label for="cookie">Enter cookie:</label>
+                </div>
+                <div>
+                    <textarea id="cookie" name="cookie" rows="20" cols="80"></textarea>
+                </div>
+                <div class="button">
+                    <button type="submit">Submit</button>
+                </div>
+            </form>
+        </div>
+
+    </body>
+</html>

--- a/app/views/cookieInfo/userSnippet.scala.html
+++ b/app/views/cookieInfo/userSnippet.scala.html
@@ -1,0 +1,12 @@
+@import com.gu.pandomainauth.model.AuthenticatedUser
+@import org.joda.time.DateTime
+@(user: AuthenticatedUser)
+<div>
+    <p><b>First name:</b> @user.user.firstName</p>
+    <p><b>Last name:</b> @user.user.lastName</p>
+    <p><b>Email:</b> @user.user.email</p>
+    <p><b>Avatar URL:</b> @user.user.avatarUrl.map(_.length).map{l => (@l chars)}: @user.user.avatarUrl.getOrElse("None")</p>
+    <p><b>Authenticating system:</b> @user.authenticatingSystem</p>
+    <p><b>Authenticated in:</b> @user.authenticatedIn.mkString("; ")</p>
+    <p><b>Expires at:</b> @user.expires <i>(@{new DateTime(user.expires).toString})</i></p>
+</div>

--- a/conf/routes
+++ b/conf/routes
@@ -18,6 +18,9 @@ GET     /emergency/new-cookie/:token controllers.Emergency.issueNewCookie(token)
 + NOCSRF
 POST    /emergency/send-cookie-link  controllers.Emergency.sendCookieLink
 
+GET     /decode                      controllers.CookieInfo.decodeForm
+POST    /decode                      controllers.CookieInfo.decodeCookie
+
 + NOCSRF
 POST    /switches/emergency/on       controllers.SwitchesController.emergencyOn
 + NOCSRF


### PR DESCRIPTION
## What does this change?
It is often the case that we have a panda cookie that we need to decode but this is difficult to do as the format is not standard. This adds a `/decode` endpoint to the login service that allows you to paste in a cookie and it will be decoded as much as possible.

## How can we measure success?
This is a developer tool that is useful for debugging certain classes of issues.

## Images
Form to fill in:
![image](https://user-images.githubusercontent.com/1236466/104816429-0798a800-5813-11eb-93b9-c1579190cb8b.png)

Normal authenticated user display:
![image](https://user-images.githubusercontent.com/1236466/104816435-15e6c400-5813-11eb-890f-e41a7d8ac075.png)

Uh-ho, something went wrong display:
![image](https://user-images.githubusercontent.com/1236466/104816447-2434e000-5813-11eb-854e-c8100f67f1a2.png)
