### PR TITLE
[WIP] very rough beginnings of an OIDC implementation

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -29,6 +29,15 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
   val emergency = new Emergency(loginPublicSettings, this, aws.dynamoDbClient, aws.sesClient)
   val login = new Login(this, aws.dynamoDbClient)
   val switchesController = new SwitchesController(this, aws.dynamoDbClient)
+  val oidcController = new OIDC(this, aws.dynamoDbClient)
 
-  override lazy val router = new Routes(httpErrorHandler, app, login, emergency, switchesController, assets)
+  override lazy val router = new Routes(
+    httpErrorHandler,
+    app,
+    login,
+    oidcController,
+    emergency,
+    switchesController,
+    assets
+  )
 }

--- a/app/controllers/OIDC.scala
+++ b/app/controllers/OIDC.scala
@@ -1,0 +1,95 @@
+package controllers
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.gu.pandomainauth.model.Authenticated
+import com.nimbusds.jose.{EncryptionMethod, JWEAlgorithm}
+import org.pac4j.jwt.config.encryption.RSAEncryptionConfiguration
+import org.pac4j.jwt.config.signature.RSASignatureConfiguration
+import org.pac4j.jwt.profile.JwtGenerator
+import play.api.libs.json.Json
+import play.api.mvc.RequestHeader
+
+import java.security.KeyPairGenerator
+import java.util
+
+class OIDC(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB) extends LoginController(deps, dynamoDbClient) {
+
+  // TODO surely these will need to come from config, so they're the same every time
+  val keyGen = KeyPairGenerator.getInstance("RSA")
+  val rsaKeyPair = keyGen.generateKeyPair()
+
+  val jwtSignatureConfig = new RSASignatureConfiguration(rsaKeyPair);
+
+  val jwtGenerator = new JwtGenerator(
+    jwtSignatureConfig/*,
+    new RSAEncryptionConfiguration(
+      rsaKeyPair,
+      JWEAlgorithm.RSA_OAEP_256,
+      EncryptionMethod.A256GCM
+    )*/
+  );
+
+  // bare minimum : all REQUIRED fields from https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+  case class DiscoveryResponse(
+    issuer: String,
+    authorization_endpoint: String,
+    token_endpoint: String,
+    userinfo_endpoint: String,
+    jwks_uri: String,
+    response_types_supported: List[String],
+    subject_types_supported: List[String],
+    id_token_signing_alg_values_supported: List[String]
+  )
+  implicit val writesDiscoveryResponse = Json.writes[DiscoveryResponse]
+
+  private def issuerURL(implicit request: RequestHeader) = s"https://${request.host}/oidc"
+
+  def discovery = Action { implicit request =>
+    Ok(Json.toJson(DiscoveryResponse(
+      issuer = issuerURL,
+      authorization_endpoint = routes.OIDC.auth().absoluteURL(secure = true),
+      token_endpoint = routes.OIDC.token().absoluteURL(secure = true),
+      userinfo_endpoint = routes.OIDC.userInfo().absoluteURL(secure = true),
+      jwks_uri = routes.OIDC.jwks().absoluteURL(secure = true),
+      response_types_supported = List("token"),
+      subject_types_supported = List("public"),
+      id_token_signing_alg_values_supported = List(jwtSignatureConfig.getAlgorithm.getName)
+    ))).as("application/json")
+  }
+
+  def auth = AuthAction { implicit request =>
+    Ok("authenticated")
+  }
+  def token = Action { implicit request =>
+
+    extractAuth(request) match {
+      case Authenticated(authedUser) => {
+        // TODO header missing 'kid' which should correspond to what's served on jwks endpoint
+        val claims = new util.HashMap[String, Object]()
+        claims.put("iss", issuerURL)
+        claims.put("sub", authedUser.user.email) // TODO is this a safe value given spec 'A locally unique and never reassigned identifier within the Issuer for the End-User'
+        claims.put("email", authedUser.user.email)
+        claims.put("aud", authedUser.authenticatedIn)
+        claims.put("exp", new java.lang.Long(authedUser.expires / 1000)) // TODO do we re-use the cookie expiry or set a new expiry relative to token generation (e.g. plus one hour)
+        claims.put("iat", new java.lang.Long(System.currentTimeMillis() / 1000))
+//        claims.put("auth_time", authedUser.) //TODO figure out a way to get this from the original auth
+        Ok(
+          jwtGenerator.generate(
+            claims
+          )
+        )
+      }
+      case otherStatus => Unauthorized(otherStatus.getClass.getSimpleName)
+    }
+
+
+  }
+  //TODO consider extending AuthAction to make use of token in Authentication header
+  def userInfo = AuthAction { implicit request =>
+    Ok(request.user.toJson).as("application/json")
+  }
+  def jwks = Action { implicit request =>
+    Ok("") //TODO expose keyset with id matching what will be on the 'kid' in token header
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,8 @@ libraryDependencies ++= Seq(
   "com.github.t3hnar" %% "scala-bcrypt" % "3.1",
   "com.gu" %% "scanamo" % "1.0.0-M6",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
-  "com.gu" %% "anghammarad-client" % "1.1.3"
+  "com.gu" %% "anghammarad-client" % "1.1.3",
+  "org.pac4j" % "pac4j-jwt" % "4.4.0"
 )
 
 lazy val mainProject = project.in(file("."))

--- a/conf/routes
+++ b/conf/routes
@@ -2,29 +2,37 @@
 # This file defines all application routes (Higher priority routes first)
 # ~~~~
 
-GET     /                           controllers.Application.index
+GET     /                                           controllers.Application.index
 
-GET     /login                       controllers.Application.login(returnUrl: String)
+GET     /login                                      controllers.Application.login(returnUrl: String)
 
-GET     /showUser                    controllers.Login.status
-GET     /oauthCallback               controllers.Login.oauthCallback
-GET     /logout                      controllers.Login.logout
-GET     /whoami                      controllers.Login.whoami
+GET     /showUser                                   controllers.Login.status
+GET     /oauthCallback                              controllers.Login.oauthCallback
+GET     /logout                                     controllers.Login.logout
+GET     /whoami                                     controllers.Login.whoami
 
-GET     /emergency/reissue           controllers.Emergency.reissue
-GET     /emergency/reissue-disabled  controllers.Emergency.reissueDisabled
-GET     /emergency/request-cookie    controllers.Emergency.requestCookieLink
-GET     /emergency/new-cookie/:token controllers.Emergency.issueNewCookie(token)
+GET     /oidc/.well-known/openid-configuration      controllers.OIDC.discovery
+GET     /oidc/auth                                  controllers.OIDC.auth
+POST    /oidc/auth                                  controllers.OIDC.auth
+GET     /oidc/token                                 controllers.OIDC.token
+POST    /oidc/token                                 controllers.OIDC.token
+GET     /oidc/userinfo                              controllers.OIDC.userInfo
+GET     /oidc/jwks                                 controllers.OIDC.jwks
+
+GET     /emergency/reissue                          controllers.Emergency.reissue
+GET     /emergency/reissue-disabled                 controllers.Emergency.reissueDisabled
+GET     /emergency/request-cookie                   controllers.Emergency.requestCookieLink
+GET     /emergency/new-cookie/:token                controllers.Emergency.issueNewCookie(token)
 + NOCSRF
-POST    /emergency/send-cookie-link  controllers.Emergency.sendCookieLink
+POST    /emergency/send-cookie-link                 controllers.Emergency.sendCookieLink
 
 + NOCSRF
-POST    /switches/emergency/on       controllers.SwitchesController.emergencyOn
+POST    /switches/emergency/on                      controllers.SwitchesController.emergencyOn
 + NOCSRF
-POST    /switches/emergency/off      controllers.SwitchesController.emergencyOff
-GET     /switches                    controllers.SwitchesController.index
+POST    /switches/emergency/off                     controllers.SwitchesController.emergencyOff
+GET     /switches                                   controllers.SwitchesController.index
 
-GET     /_healthcheck                controllers.Application.healthCheck
+GET     /_healthcheck                               controllers.Application.healthCheck
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file                controllers.Assets.versioned(path="/public", file: Asset)
+GET     /assets/*file                               controllers.Assets.versioned(path="/public", file: Asset)


### PR DESCRIPTION
https://trello.com/c/c7RrjrEW/537-move-from-apikey-auth-to-openid

The original motivation behind making login.gutools an OIDC provider is to allow us to change pinboard's authentication model to Open ID Connect, but will likely have wider benefits to the team/department (not least because many AWS services offer OIDC as auth option). Pinboard currently use API Keys, which are limited to 50 and have a min expiry of 24 hours (currently we exchange the panda cookie for a generated API key, in https://github.com/guardian/editorial-tools-pinboard/tree/main/bootstrapping-lambda).

This PR represents the beginnings of such an implementation but is far from finished, but I've had to park this work to move onto more pressing pinboard features and so have made a [tactical change to pinboard to make the API approach last a little longer](https://github.com/guardian/editorial-tools-pinboard/pull/41). At the very least the following items are outstanding...

- load RSA key pair from config (rather than generating on the host machine)
- /oidc/jwks needs to return the key details for above, and `kid` property in the JWT token header needs to point to said key(s)
- need to ensure signature signing works (probably dependant on the above two tasks)
- almost def. need to support different types of tokens (access vs id etc.) as per the spec

## Key Links
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
https://openid.net/specs/openid-connect-core-1_0.html#IDToken 