### PR TITLE
upgrade AWS SDK to min. version required for IMDSv2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions := Seq(
   "-Ypartial-unification"
 )
 
-val awsSdkVersion = "1.11.569"
+val awsSdkVersion = "1.11.678"
 
 resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
 


### PR DESCRIPTION
_This is a pre-requisite for https://github.com/guardian/editorial-tools-platform/pull/530_

Upgrade AWS SDK to min. version required for IMDSv2 to address https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-8-remediation as per https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2

**✅  Tested in `CODE`**, the below graph shows drop-off in usage of IMDSv1 for the relevant ASG...
![image](https://user-images.githubusercontent.com/19289579/115250628-ac33ca00-a121-11eb-932b-922811375995.png)
