### PR TITLE
Update instructions to include DynamoDB table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ sbt console
 import com.github.t3hnar.bcrypt._
 "[password-value]".bcrypt
 ```
+Add a new item to the Composer DynamoDB table `login.gutools-emergency-access-[STAGE]` containing the userId and password hash.
 
 To turn a switch on or off run:
 ```


### PR DESCRIPTION
## What does this change?
Adds a line in the instructions in the 'Emergency access when Google auth is down' section of the README to indicate which table to edit in DynamoDB.