### PR TITLE
Update Scanamo to 1.0.0-M17

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -25,10 +25,10 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
     Future.successful(())
   })
 
-  val app = new Application(this, aws.dynamoDbClient)
-  val emergency = new Emergency(loginPublicSettings, this, aws.dynamoDbClient, aws.sesClient)
-  val login = new Login(this, aws.dynamoDbClient)
-  val switchesController = new SwitchesController(this, aws.dynamoDbClient)
+  val app = new Application(this)
+  val emergency = new Emergency(loginPublicSettings, this, aws.sesClient)
+  val login = new Login(this)
+  val switchesController = new SwitchesController(this)
 
   override lazy val router = new Routes(httpErrorHandler, app, login, emergency, switchesController, assets)
 }

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -24,12 +24,13 @@ case class InstanceTags(stack: String, app: String, stage: String)
 
 class AWS {
   val region = Region.getRegion(Regions.EU_WEST_1).getName
+  val profile = "composer"
 
   val composerAwsCredentialsProvider = new AWSCredentialsProviderChain(
     new EnvironmentVariableCredentialsProvider(),
     new SystemPropertiesCredentialsProvider(),
     InstanceProfileCredentialsProvider.getInstance(),
-    new ProfileCredentialsProvider("composer")
+    new ProfileCredentialsProvider(profile)
   )
 
   val asgClient: AmazonAutoScaling = AmazonAutoScalingClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -5,11 +5,18 @@ import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCrede
 import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
 import com.amazonaws.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, DescribeAutoScalingInstancesRequest}
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClientBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.simpleemail.{AmazonSimpleEmailService, AmazonSimpleEmailServiceClientBuilder}
 import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
 import com.amazonaws.util.EC2MetadataUtils
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.regions.{Region => RegionV2}
+import software.amazon.awssdk.auth.credentials.{
+  AwsCredentialsProviderChain,
+  EnvironmentVariableCredentialsProvider => EnvironmentVariableCredentialsProviderV2,
+  InstanceProfileCredentialsProvider => InstanceProfileCredentialsProviderV2,
+  ProfileCredentialsProvider => ProfileCredentialsProviderV2
+}
 
 import scala.collection.JavaConverters._
 
@@ -30,7 +37,17 @@ class AWS {
 
   val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
   val sesClient: AmazonSimpleEmailService = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
-  val dynamoDbClient: AmazonDynamoDB = AmazonDynamoDBClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
+
+  private val v2CredentialsProvider = AwsCredentialsProviderChain.builder.credentialsProviders(
+    ProfileCredentialsProviderV2.builder.profileName(profile).build,
+    InstanceProfileCredentialsProviderV2.builder.asyncCredentialUpdateEnabled(false).build,
+    EnvironmentVariableCredentialsProviderV2.create()
+  ).build
+
+  val dynamoDbClient: DynamoDbClient = DynamoDbClient.builder
+    .credentialsProvider(v2CredentialsProvider)
+    .region(RegionV2.EU_WEST_1)
+    .build()
 
   def readTags(): Option[InstanceTags] = {
     // We read tags from the AutoScalingGroup rather than the instance itself to avoid problems where the

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,12 +1,9 @@
 package controllers
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import config.LoginConfig
 import login.BuildInfo
+import config.LoginConfig
 
-
-class Application(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB)
-  extends LoginController(deps, dynamoDbClient) {
+class Application(deps: LoginControllerComponents) extends LoginController(deps) {
 
   def login(returnUrl: String) = AuthAction { implicit request =>
     if (LoginConfig.isValidUrl(config.domain, returnUrl)) {

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,25 +1,25 @@
 package controllers
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
 import com.github.nscala_time.time.Imports._
 import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
 import com.gu.pandomainauth.service.CookieUtils
-import com.gu.pandomainauth.{PublicKey, PublicSettings}
-import com.gu.scanamo._
-import com.gu.scanamo.error.DynamoReadError
-import com.gu.scanamo.syntax._
-import config.LoginPublicSettings
+import com.gu.pandomainauth.PublicSettings
 import play.api.mvc._
+import services.{NewCookieIssue, TokenDBService}
 import utils._
 
 import scala.util.Random
 import scala.util.control.NonFatal
 
+class Emergency(
+   loginPublicSettings: PublicSettings,
+   deps: LoginControllerComponents,
+   tokenDB: TokenDBService,
+   sesClient: AmazonSimpleEmailService
+) extends LoginController(deps) with Loggable {
 
-class Emergency(loginPublicSettings: LoginPublicSettings, deps: LoginControllerComponents,
-                dynamoDbClient: AmazonDynamoDB, sesClient: AmazonSimpleEmailService)
-  extends LoginController(deps, dynamoDbClient) with Loggable {
+  private val cookieLifetime = 1.day
 
   val cookieLifetime = 1.day
 
@@ -77,7 +77,8 @@ class Emergency(loginPublicSettings: LoginPublicSettings, deps: LoginControllerC
         tokenIssuedAt, false)
 
       try {
-        val userOpt = Scanamo.put[NewCookieIssue](dynamoDbClient)(config.tokensTableName)(cookieIssue)
+        tokenDB.createCookieIssue(cookieIssue)
+
         val ses = new SES(sesClient, config)
         ses.sendCookieEmail(token, emailAddress)
 
@@ -92,29 +93,27 @@ class Emergency(loginPublicSettings: LoginPublicSettings, deps: LoginControllerC
     }
   }
 
-  def issueNewCookie(userToken: String) = EmergencySwitchIsOnAction { req =>
+  def issueNewCookie(userToken: String): Action[AnyContent] = EmergencySwitchIsOnAction {
 
-    def issueNewCookie(tokenEntry: NewCookieIssue, tableName: String) = {
-      val updatedTokenEntry = Scanamo.put[NewCookieIssue](dynamoDbClient)(tableName)(tokenEntry.copy(used = true))
+    def issueNewCookie(newCookieIssue: NewCookieIssue): Result = {
+      tokenDB.expireCookieIssue(newCookieIssue)
+
       val expires = (DateTime.now() + cookieLifetime).getMillis
-      val names = tokenEntry.email.split("\\.")
+      val names = newCookieIssue.email.split("\\.")
       val firstName = names(0).capitalize
       val lastName = names(1).split("@")(0).capitalize
-      val user = User(firstName, lastName, tokenEntry.email, None)
-      val newAuthUser = AuthenticatedUser(user, config.appName, Set(config.appName), expires, true)
-      val authCookies = generateCookies(newAuthUser)
+      val user = User(firstName, lastName, newCookieIssue.email, None)
+      val newAuthUser = AuthenticatedUser(user, config.appName, Set(config.appName), expires, multiFactor = true)
+      val authCookie = generateCookie(newAuthUser)
 
       Ok(views.html.emergency.reissueSuccess())
         .withCookies(authCookies: _*)
     }
 
-    val newCookieTopic = "A new cookie has not been created"
     val issueNewCookieTopic = "New cookie has not been created"
     val tenMinutesInMilliSeconds = 600000
 
-    val tableName = config.tokensTableName
-    val tokenOpt: Option[Either[DynamoReadError, NewCookieIssue]] =
-      Scanamo.get[NewCookieIssue](dynamoDbClient)(tableName)('id -> s"$userToken")
+    val tokenOpt = tokenDB.getCookieIssueForUserToken(userToken)
 
     tokenOpt.map {
       case Left(error) => {
@@ -129,7 +128,7 @@ class Emergency(loginPublicSettings: LoginPublicSettings, deps: LoginControllerC
             Unauthorized(views.html.emergency.newCookieFailure("Your link has expired. Could not create a new cookie"))
           }
           else {
-            issueNewCookie(tokenEntry, tableName)
+            issueNewCookie(tokenEntry)
           }
         } else {
           log.warn(s"Attempted to use a used token: ${tokenEntry.id}")
@@ -144,8 +143,5 @@ class Emergency(loginPublicSettings: LoginPublicSettings, deps: LoginControllerC
     log.warn(message)
     Unauthorized(views.html.emergency.reissueFailure(message, topic))
   }
-
 }
-
-case class NewCookieIssue(id: String, email: String, requested: Long, used: Boolean)
 

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,10 +1,9 @@
 package controllers
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import config.LoginConfig
 import play.api.mvc._
 
-class Login(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB) extends LoginController(deps, dynamoDbClient) {
+class Login(deps: LoginControllerComponents) extends LoginController(deps) {
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
   def oauthCallback = Action.async { implicit request =>

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -108,10 +108,9 @@ abstract class LoginController(deps: LoginControllerComponents, dynamoDbClient: 
       try {
         val authHeaderUser = EmergencyActions.getBasicAuthDetails(request.headers)
         val userId = authHeaderUser.id
-        val tableName = config.emergencyAccessTableName
-        val userOpt = Scanamo.get[EmergencyUser](dynamoDbClient)(tableName)('userId -> s"$userId")
+        val userOpt = deps.emergencyUserDBService.getUser(userId)
         userOpt.map {
-          case Left(error) => refuseSwitchChange(s"Error with reading $userId from Dynamo. User will be refused access to change emergency switch.")
+          case Left(error) => refuseSwitchChange(s"Error with reading $userId from Dynamo: ${error.toString}. User will be refused access to change emergency switch.")
           case Right(user) => checkPassword(user, userId, authHeaderUser.password)
         }.getOrElse(refuseSwitchChange(s"User $userId not found. User will be refused access to change emergency switch."))
       } catch {

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -53,7 +53,7 @@ abstract class LoginControllerComponents(
   }
 }
 
-abstract class LoginController(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB) extends BaseController with AuthActions with Loggable {
+abstract class LoginController(deps: LoginControllerComponents) extends BaseController with AuthActions with Loggable {
   final override def wsClient: WSClient = deps.wsClient
   final override def controllerComponents: ControllerComponents = deps.controllerComponents
 

--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -1,9 +1,8 @@
 package controllers
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import config.{Off, On, SwitchState}
 
-class SwitchesController(deps: LoginControllerComponents, dynamoDbClient: AmazonDynamoDB) extends LoginController(deps, dynamoDbClient) {
+class SwitchesController(deps: LoginControllerComponents) extends LoginController(deps) {
 
   private def errorMessage(state: SwitchState)  = s"Failed to update Emergency switch to ${state.name}. Contact digitalcms.dev@theguardian.com for more help."
   private def success(state: SwitchState)  = s"Emergency switch updated to ${state.name}"

--- a/app/services/EmergencyUserDBservice.scala
+++ b/app/services/EmergencyUserDBservice.scala
@@ -1,0 +1,25 @@
+package services
+
+import org.scanamo.{Scanamo, Table}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import org.scanamo._
+import org.scanamo.syntax._
+import org.scanamo.generic.auto._
+import scala.concurrent.{ExecutionContext}
+import scala.util.Either
+
+case class EmergencyUser(userId: String, passwordHash: String)
+
+/**
+  * Service to manage persistence of emergency user records.
+  */
+class EmergencyUserDBService(
+  client: DynamoDbClient,
+  tableName: String
+)(implicit executionContext: ExecutionContext) {
+
+  private val table = Table[EmergencyUser](tableName)
+  private def run[T] = Scanamo(client).exec[T] _
+
+  def getUser(userId: String): Option[Either[DynamoReadError, EmergencyUser]] = run(table.get("userId" === userId))
+}

--- a/app/services/EmergencyUserDBservice.scala
+++ b/app/services/EmergencyUserDBservice.scala
@@ -5,8 +5,9 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import scala.concurrent.{ExecutionContext}
+import scala.concurrent.ExecutionContext
 import scala.util.Either
+import scala.language.higherKinds
 
 case class EmergencyUser(userId: String, passwordHash: String)
 

--- a/app/services/TokenDBService.scala
+++ b/app/services/TokenDBService.scala
@@ -1,0 +1,34 @@
+package services
+
+import org.scanamo.{Scanamo, Table}
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import org.scanamo._
+import org.scanamo.syntax._
+import org.scanamo.generic.auto._
+import scala.concurrent.{ExecutionContext}
+import scala.util.Either
+
+case class NewCookieIssue(id: String, email: String, requested: Long, used: Boolean)
+
+/**
+  * Service to manage persistence of user cookies.
+  */
+class TokenDBService(
+  client: DynamoDbClient,
+  tableName: String
+)(implicit executionContext: ExecutionContext) {
+
+  private val table = Table[NewCookieIssue](tableName)
+  private def run[T] = Scanamo(client).exec[T] _
+
+  def getCookieIssueForUserToken(userToken: String): Option[Either[DynamoReadError, NewCookieIssue]] =
+    run(table.get("id" === userToken))
+
+  def createCookieIssue(cookieIssue: NewCookieIssue): Unit = {
+    run(table.put(cookieIssue))
+  }
+
+  def expireCookieIssue(cookieIssue: NewCookieIssue): Unit = {
+    run(table.put(cookieIssue.copy(used = true)))
+  }
+}

--- a/app/services/TokenDBService.scala
+++ b/app/services/TokenDBService.scala
@@ -5,8 +5,9 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import org.scanamo._
 import org.scanamo.syntax._
 import org.scanamo.generic.auto._
-import scala.concurrent.{ExecutionContext}
+import scala.concurrent.ExecutionContext
 import scala.util.Either
+import scala.language.higherKinds
 
 case class NewCookieIssue(id: String, email: String, requested: Long, used: Boolean)
 

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,11 @@ scalacOptions := Seq(
   "-Ypartial-unification"
 )
 
-val awsSdkVersion = "1.11.678"
+
+// We must include both AWS SDK V1 and V2 to enable the use of latest
+// Scanamo whilst avoiding overhauling the whole app to V2.
+val awsSdkVersion = "1.12.130"
+val awsSdkVersionV2 = "2.17.101"
 
 resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
 
@@ -24,16 +28,16 @@ libraryDependencies ++= Seq(
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.14",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-autoscaling" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-ses" % awsSdkVersion,
   "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
+  "software.amazon.awssdk" % "dynamodb" % awsSdkVersionV2,
   "net.logstash.logback" % "logstash-logback-encoder" % "6.0",
   "com.gu" % "kinesis-logback-appender" % "1.4.4",
   "com.github.nscala-time" %% "nscala-time" % "2.18.0",
   "com.github.t3hnar" %% "scala-bcrypt" % "3.1",
-  "com.gu" %% "scanamo" % "1.0.0-M6",
+  "org.scanamo" %% "scanamo" % "1.0.0-M17",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "com.gu" %% "anghammarad-client" % "1.1.3"
 )


### PR DESCRIPTION
## What does this change?

Updates Scanamo to latest, 1.0.0-M17.

This is a more involved change than we might expect for two reasons:
  - Scanamo latest requires AWS SDK V2, which means configuring and scaffolding for a new dependency (coexisting with V1)
  - The changes to Scanamo's table configuration were significant enough that I felt it was a good time to abstract the DB ops away from our controllers into their own services.

It paves the way for updating Scala to 2.13.

## How to test

This change should be a no-op. Test the following locally, or in CODE (I've tested in CODE where ticked):

- [x] Logging in
- [x] Turning on the emergency switch – access denied
- [x] Turning on the emergency switch – access granted
- [x] Using the tool to extend the cookie
- [x] Using the tool to email the user a link to a new cookie
- [x] Using that cookie (incognito tab)
- [x] Link is invalidated after use