### PR TITLE
Bump panda to 1.0.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositori
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.4",
+  "com.gu" %% "pan-domain-auth-play_2-8" % "1.0.6",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.18",
   "com.gu.play-secret-rotation" %% "play-v28" % "0.31",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
## What does this change?

Bumps pan-domain-auth to 1.0.6 to patch some security vulnerabilities.

## How to test

The app should continue to accept authenticated requests, and reject unauthenticated ones.

Deploy to CODE and log in. Does the tool continue to authenticate you? Remove your pan-domain cookies, and try again. Does it force you to log in?