### PR TITLE
mint cookies on the super-domain `dev-gutools.co.uk` when running in `CODE` AND if the `returnUrl` is a `local.dev-gutools.co.uk`

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -3,12 +3,24 @@ package controllers
 import login.BuildInfo
 import config.LoginConfig
 
+import java.net.URL
+
 class Application(deps: LoginControllerComponents) extends LoginController(deps) {
 
+  private val localDomain = "local.dev-gutools.co.uk"
+
   def login(returnUrl: String) = AuthAction { implicit request =>
-    if (LoginConfig.isValidUrl(config.domain, returnUrl)) {
+    if(new URL(returnUrl).getHost.endsWith(localDomain)) {
+      readCookie(request).filter(_.domain.contains("code.dev-gutools.co.uk")).foreach { _ =>
+        flushCookie(
+          Redirect(request.uri)
+        )
+      }
+    }
+    if (LoginConfig.isValidUrl(config.domain, returnUrl) || LoginConfig.isValidUrl(localDomain, returnUrl)) {
       Redirect(returnUrl)
-    } else {
+    }
+    else {
       Ok("Please redirect to a valid, secure url on the relevant stage")
     }
   }

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -7,7 +7,15 @@ class Login(deps: LoginControllerComponents) extends LoginController(deps) {
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
   def oauthCallback = Action.async { implicit request =>
-    processOAuthCallback()
+    val resultFuture = processOAuthCallback()
+    if (config.domain == "code.dev-gutools.co.uk") {
+      resultFuture.map(result => result.copy(
+        newCookies = result.newCookies.map(_.copy(domain = Some("dev-gutools.co.uk")))
+      ))(controllerComponents.executionContext)
+    }
+    else {
+      resultFuture
+    }
   }
 
   def status = AuthAction { request =>


### PR DESCRIPTION
...so we can redirect to `login.code.dev-gutools.co.uk` for tools using [`@guardian/pan-domain-node`](https://www.npmjs.com/package/@guardian/pan-domain-node) which can only verify cookies not mint them (see https://github.com/guardian/pan-domain-authentication/#to-verify-login-in-nodejs) and have it mint cookies on `dev-gutools.co.uk` so the browser provides them to applications running on `*.local.dev-gutools.co.uk`.