### PR TITLE
ci: Adopt GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Allow GitHub to request an OIDC JWT ID token, for exchange with `aws-actions/configure-aws-credentials`
+      # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#updating-your-github-actions-workflow
+      id-token: write
+
+      # Required for `actions/checkout`
+      contents: read
+
+    steps:
+      # Checkout the branch
+      - uses: actions/checkout@v3
+
+      # Java is needed for the Scala Play app
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'corretto'
+          cache: 'sbt'
+
+      # Seed the build number with last number from TeamCity.
+      # This env var is used by the SBT builds and guardian/actions-riff-raff.
+      # Set the value early, rather than `buildNumberOffset` in guardian/actions-riff-raff, to ensure each usage has the same number.
+      # For some reason, it's not possible to mutate GITHUB_RUN_NUMBER, so set BUILD_NUMBER instead.
+      - name: Set BUILD_NUMBER environment variable
+        run: |
+          LAST_TEAMCITY_BUILD=143
+          echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
+
+      - name: Scala build
+        run: sbt clean compile test Debian/packageBin
+
+      - name: Rename files for easy finding by guardian/actions-riff-raff
+        run: mv target/login_1.0.0_all.deb login.deb
+
+      # Fetch AWS credentials, allowing us to upload to Riff-Raff (well, S3)
+      - uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+
+      # Upload our build artifacts to Riff-Raff (well, S3)
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          buildNumber: ${{ env.BUILD_NUMBER }}
+          projectName: editorial-tools:login
+          configPath: riff-raff.yaml
+          contentDirectories: |
+            login:
+              - login.deb

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -2,6 +2,7 @@ package controllers
 
 import login.BuildInfo
 import config.LoginConfig
+import play.api.libs.json.Json
 
 class Application(deps: LoginControllerComponents) extends LoginController(deps) {
 
@@ -14,7 +15,7 @@ class Application(deps: LoginControllerComponents) extends LoginController(deps)
   }
 
   def healthCheck() = Action { implicit request =>
-    Ok(BuildInfo.gitCommitId)
+    Ok(Json.parse(BuildInfo.toJson))
   }
 
   def index() = Action { implicit request => Ok("A small application to login a user via pan-domain-auth and redirect them.")}

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -14,9 +14,10 @@ class Application(deps: LoginControllerComponents) extends LoginController(deps)
     }
   }
 
-  def healthCheck() = Action { implicit request =>
+  def healthCheck() = Action { implicit request => {
+    log.info("Responding from the healthcheck")
     Ok(Json.parse(BuildInfo.toJson))
-  }
+  }}
 
   def index() = Action { implicit request => Ok("A small application to login a user via pan-domain-auth and redirect them.")}
 }

--- a/app/management/BuildInfo.scala
+++ b/app/management/BuildInfo.scala
@@ -1,0 +1,5 @@
+package management
+
+trait BuildInfo {
+  def toJson: String
+}

--- a/app/utils/ElkLogging.scala
+++ b/app/utils/ElkLogging.scala
@@ -26,7 +26,7 @@ class ElkLogging(stage: String,
       "stage" -> stage,
       "stack" -> "flexible",
       "region" -> region,
-      "buildNumber" -> BuildInfo.buildNumber
+      "buildNumber" -> BuildInfo.buildNumber.getOrElse("DEV")
     )
     log.info(s"Logging with context map: $effective")
     effective

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,6 @@
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
## What does this change?
Adopts GitHub Actions for CI, replacing TeamCity. This involves removing the deprecated SBT plugin [sbt-riffraff-artifact](https://github.com/guardian/sbt-riffraff-artifact) in favour of [https://github.com/guardian/actions-riff-raff](https://github.com/guardian/actions-riff-raff).

## How to test
There are four tests we can do.

1. [Deploy this branch. It should succeed](https://riffraff.gutools.co.uk/deployment/view/ec57aa40-0fe7-423e-9f58-7faf575535d7).
2. With this branch on CODE, interact with another service that uses login.gutools CODE, for example [S3 Uploader](https://s3-uploader.code.dev-gutools.co.uk/). You should successfully login.
3. On [`main`](https://github.com/guardian/login.gutools/blob/54c7067f71b98c689f174d704c018e0135bf6394/app/controllers/Application.scala#L16-L18), the `/_healthcheck` endpoint returns the commit SHA. On this branch, we return the entire build info as JSON. Visit the [`/_healthcheck` endpoint](https://login.code.dev-gutools.co.uk/_healthcheck) and observe the response.
4. This application adds some build info markers to the logs it sends to [Central ELK](https://logs.gutools.co.uk/s/editorial-tools/goto/ee155150-481d-11ee-9469-6b1b34ff61a7). With this branch on CODE, observe these markers are still present.

## Rollout plan
- [x] Pause the TeamCity build
- [ ] Merge this PR
- [ ] Adjust branch protection rules, requiring the GHA build to pass before merge
- [ ] Ensure all open PRs are rebased against `main` to ensure their build runs