### PR TITLE
send token to desktop apps to facilitate non-browser logins

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -20,16 +20,16 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
       s3Client = aws.s3Client
     )
 
-//  private lazy val desktopPanDomainSettings: PanDomainAuthSettingsRefresher = {
-//    val domain = "local.dev-gutools-desktop.co.uk"
-//    new PanDomainAuthSettingsRefresher(
-//      domain = domain,
-//      system = "login-desktop",
-//      bucketName = config.pandaAuthBucket,
-//      settingsFileKey = s"$domain.settings",
-//      s3Client = aws.s3Client
-//    )
-//  }
+  private lazy val desktopPanDomainSettings: PanDomainAuthSettingsRefresher = {
+    val domain = "code.integration.flexible.gnl"
+    new PanDomainAuthSettingsRefresher(
+      domain = domain,
+      system = "login-desktop",
+      bucketName = config.pandaAuthBucket,
+      settingsFileKey = s"$domain.settings",
+      s3Client = aws.s3Client
+    )
+  }
 
   val loginPublicSettings = new PublicSettings(
     settingsFileKey = s"${config.domain}.settings.public",
@@ -50,7 +50,7 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
   private val app = new Application(this, panDomainSettings)
   private val emergency = new Emergency(loginPublicSettings, this, aws.sesClient, panDomainSettings)
   private val login = new Login(this, panDomainSettings)
-  private val desktopLogin = new DesktopLogin(this, panDomainSettings)
+  private val desktopLogin = new DesktopLogin(this, desktopPanDomainSettings)
   private val switchesController = new SwitchesController(this, panDomainSettings)
 
   override lazy val router = new Routes(httpErrorHandler, app, desktopLogin, login, emergency, switchesController, assets)

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -21,7 +21,7 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
     )
 
   private lazy val desktopPanDomainSettings: PanDomainAuthSettingsRefresher = {
-    val domain = "code.integration.flexible.gnl"
+    val domain = config.desktopDomain
     new PanDomainAuthSettingsRefresher(
       domain = domain,
       system = "login-desktop",

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -21,12 +21,11 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
     )
 
   private lazy val desktopPanDomainSettings: PanDomainAuthSettingsRefresher = {
-    val domain = config.desktopDomain
     new PanDomainAuthSettingsRefresher(
-      domain = domain,
+      domain = config.desktopDomain,
       system = "login-desktop",
       bucketName = config.pandaAuthBucket,
-      settingsFileKey = s"$domain.settings",
+      settingsFileKey = s"${config.desktopDomain}.settings",
       s3Client = aws.s3Client
     )
   }

--- a/app/config/LoginConfig.scala
+++ b/app/config/LoginConfig.scala
@@ -8,6 +8,7 @@ import scala.util.control.NonFatal
 case class LoginConfig(
   stage: String,
   domain: String,
+  desktopDomain: String,
   host: String,
   appName: String,
   emergencyAccessTableName: String,
@@ -20,12 +21,17 @@ case class LoginConfig(
 )
 
 object LoginConfig {
- def forStage(stageOpt: Option[String]): LoginConfig = {
+  def forStage(stageOpt: Option[String]): LoginConfig = {
     val stage = stageOpt.getOrElse("DEV")
     val domain = stage match {
       case "PROD" => "gutools.co.uk"
       case "DEV" => "local.dev-gutools.co.uk"
-      case x => x.toLowerCase() + ".dev-gutools.co.uk"
+      case x => s"${x.toLowerCase }.dev-gutools.co.uk"
+    }
+    val desktopDomain = stage match {
+      case "DEV" => "local.integration.flexible.gnm"
+      case "CODE" => "code.integration.flexible.gnm"
+      case "PROD" => "prod.integration.flexible.gnm"
     }
     val host = "https://login." + domain
     val appName = "login.gutools"
@@ -37,13 +43,25 @@ object LoginConfig {
       "replyTo" -> "core.central.production@guardian.co.uk "
     )
 
-   val switchBucket = "login-gutools-config"
-   val pandaAuthBucket = "pan-domain-auth-settings"
+    val switchBucket = "login-gutools-config"
+    val pandaAuthBucket = "pan-domain-auth-settings"
 
-   val anghammaradSnsArn = "arn:aws:sns:eu-west-1:095768028460:anghammarad-PROD-NotificationTopic-HDJHBGZT0FFD"
+    val anghammaradSnsArn = "arn:aws:sns:eu-west-1:095768028460:anghammarad-PROD-NotificationTopic-HDJHBGZT0FFD"
 
-    LoginConfig(stage, domain, host, appName, emergencyAccessTableName, tokensTableName, tokenReissueUri,
-      emailSettings, switchBucket, pandaAuthBucket, anghammaradSnsArn)
+    LoginConfig(
+      stage = stage,
+      domain = domain,
+      desktopDomain = desktopDomain,
+      host = host,
+      appName = appName,
+      emergencyAccessTableName = emergencyAccessTableName,
+      tokensTableName = tokensTableName,
+      tokenReissueUri = tokenReissueUri,
+      emailSettings = emailSettings,
+      switchBucket = switchBucket,
+      pandaAuthBucket = pandaAuthBucket,
+      anghammaradSnsArn = anghammaradSnsArn
+    )
   }
 
   /**

--- a/app/config/LoginConfig.scala
+++ b/app/config/LoginConfig.scala
@@ -24,9 +24,9 @@ object LoginConfig {
   def forStage(stageOpt: Option[String]): LoginConfig = {
     val stage = stageOpt.getOrElse("DEV")
     val domain = stage match {
-      case "PROD" => "gutools.co.uk"
       case "DEV" => "local.dev-gutools.co.uk"
-      case x => s"${x.toLowerCase }.dev-gutools.co.uk"
+      case "CODE" => "code.dev-gutools.co.uk"
+      case "PROD" => "gutools.co.uk"
     }
     val desktopDomain = stage match {
       case "DEV" => "local.integration.flexible.gnm"

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,10 +1,19 @@
 package controllers
 
-import login.BuildInfo
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.LoginConfig
+import login.BuildInfo
+import play.api.Logging
 import play.api.libs.json.Json
 
-class Application(deps: LoginControllerComponents) extends LoginController(deps) {
+import scala.concurrent.ExecutionContext
+
+class Application(
+  deps: LoginControllerComponents,
+  panDomainSettings: PanDomainAuthSettingsRefresher
+) extends LoginController(deps, panDomainSettings) with Logging {
+
+  implicit val ec: ExecutionContext = deps.executionContext
 
   def login(returnUrl: String) = AuthAction { implicit request =>
     if (LoginConfig.isValidUrl(config.domain, returnUrl)) {

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
-import com.gu.pandomainauth.service.{CookieUtils, OAuthException}
+import com.gu.pandomainauth.service.OAuthException
 import play.api.Logging
 import play.api.mvc.{Action, AnyContent}
 

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -57,7 +57,7 @@ class DesktopLogin(
 
       if (validateUser(authedUserData)) {
         val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.privateKey)
-        Redirect(s"gnm://auth/token/${URLEncoder.encode(token, "UTF-8")}")
+        Redirect(s"gnm://auth/token/${URLEncoder.encode(token, "UTF-8")}/stage/${deps.config.stage.toLowerCase}")
           .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
       } else {
         showUnauthedMessage(invalidUserMessage(claimedAuth))

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -49,7 +49,7 @@ class DesktopLogin(
       if (validateUser(authedUserData)) {
         // TODO updates to get value separately from cookie
         val updatedCookie = generateCookie(authedUserData)
-        Redirect(s"gnm://auth/token/${URLEncoder.encode(updatedCookie.value, "UTF-8")}/")
+        Redirect(s"gnm://auth/token/${URLEncoder.encode(updatedCookie.value, "UTF-8")}")
           .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
       } else {
         showUnauthedMessage(invalidUserMessage(claimedAuth))

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -1,0 +1,59 @@
+package controllers
+
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.pandomainauth.service.{CookieUtils, OAuthException}
+import play.api.Logging
+import play.api.mvc.{Action, AnyContent}
+
+import java.net.URLEncoder
+import scala.concurrent.ExecutionContext
+
+class DesktopLogin(
+  deps: LoginControllerComponents,
+  panDomainSettings: PanDomainAuthSettingsRefresher
+) extends LoginController(deps, panDomainSettings) with Logging {
+
+  override lazy val authCallbackUrl: String = deps.config.host + "/desktopOauthCallback"
+
+  implicit private val ec: ExecutionContext = deps.executionContext
+
+  def desktopLogin: Action[AnyContent] = Action.async { implicit request =>
+    val antiForgeryToken = OAuth.generateAntiForgeryToken()
+    OAuth.redirectToOAuthProvider(antiForgeryToken, None)(ec, request, wsClient) map { _.withSession {
+      request.session + (ANTI_FORGERY_KEY -> antiForgeryToken)
+    }}
+  }
+
+  def desktopOauthCallback(): Action[AnyContent] = Action.async { implicit request =>
+    val token =
+      request.session.get(ANTI_FORGERY_KEY).getOrElse(throw new OAuthException("missing anti forgery token"))
+
+    val existingCookie = readCookie(request) // will be populated if this was a re-auth for expired login
+
+    OAuth.validatedUserIdentity(token)(request, deps.executionContext, wsClient).map { claimedAuth =>
+      val authedUserData = existingCookie match {
+        case Some(c) =>
+          val existingAuth = CookieUtils.parseCookieData(c.value, panDomainSettings.settings.publicKey)
+          logger.debug("user re-authed, merging auth data")
+
+          claimedAuth.copy(
+            authenticatingSystem = panDomainSettings.system,
+            authenticatedIn = existingAuth.authenticatedIn ++ Set(panDomainSettings.system),
+            multiFactor = checkMultifactor(claimedAuth)
+          )
+        case None =>
+          logger.debug("fresh user login")
+          claimedAuth.copy(multiFactor = checkMultifactor(claimedAuth))
+      }
+
+      if (validateUser(authedUserData)) {
+        // TODO updates to get value separately from cookie
+        val updatedCookie = generateCookie(authedUserData)
+        Redirect(s"gnm://auth/token/${URLEncoder.encode(updatedCookie.value, "UTF-8")}/")
+          .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
+      } else {
+        showUnauthedMessage(invalidUserMessage(claimedAuth))
+      }
+    }
+  }
+}

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
 import com.github.nscala_time.time.Imports._
 import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
 import com.gu.pandomainauth.service.CookieUtils
-import com.gu.pandomainauth.PublicSettings
+import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, PublicSettings}
 import play.api.mvc._
 import services.NewCookieIssue
 import utils._
@@ -15,8 +15,9 @@ import scala.util.control.NonFatal
 class Emergency(
    loginPublicSettings: PublicSettings,
    deps: LoginControllerComponents,
-   sesClient: AmazonSimpleEmailService
-) extends LoginController(deps) with Loggable {
+   sesClient: AmazonSimpleEmailService,
+   panDomainSettings: PanDomainAuthSettingsRefresher
+) extends LoginController(deps, panDomainSettings) with Loggable {
 
   private val cookieLifetime = 1.day
 
@@ -141,4 +142,3 @@ class Emergency(
     Unauthorized(views.html.emergency.reissueFailure(message, topic))
   }
 }
-

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,9 +1,12 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.LoginConfig
 import play.api.mvc._
 
-class Login(deps: LoginControllerComponents) extends LoginController(deps) {
+class Login(
+  deps: LoginControllerComponents, panDomainSettings: PanDomainAuthSettingsRefresher
+) extends LoginController(deps, panDomainSettings) {
   private val defaultAllowHeaders = List("X-Requested-With","Origin","Accept","Content-Type")
 
   def oauthCallback = Action.async { implicit request =>

--- a/app/controllers/SwitchesController.scala
+++ b/app/controllers/SwitchesController.scala
@@ -1,8 +1,11 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.{Off, On, SwitchState}
 
-class SwitchesController(deps: LoginControllerComponents) extends LoginController(deps) {
+class SwitchesController(
+  deps: LoginControllerComponents, panDomainSettings: PanDomainAuthSettingsRefresher
+) extends LoginController(deps, panDomainSettings) {
 
   private def errorMessage(state: SwitchState)  = s"Failed to update Emergency switch to ${state.name}. Contact digitalcms.dev@theguardian.com for more help."
   private def success(state: SwitchState)  = s"Emergency switch updated to ${state.name}"

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,9 @@ GET     /                           controllers.Application.index()
 
 GET     /login                       controllers.Application.login(returnUrl: String)
 
+GET     /desktop-login               controllers.DesktopLogin.desktopLogin()
+GET     /desktopOauthCallback        controllers.DesktopLogin.desktopOauthCallback()
+
 GET     /showUser                    controllers.Login.status()
 GET     /oauthCallback               controllers.Login.oauthCallback()
 GET     /logout                      controllers.Login.logout()

--- a/conf/routes
+++ b/conf/routes
@@ -8,7 +8,7 @@ GET     /login                       controllers.Application.login(returnUrl: St
 
 GET     /desktop/login               controllers.DesktopLogin.desktopLogin()
 GET     /desktop/showUser            controllers.DesktopLogin.authStatus()
-GET     /desktop/oauthCallback        controllers.DesktopLogin.desktopOauthCallback()
+GET     /desktop/oauthCallback       controllers.DesktopLogin.desktopOauthCallback()
 
 GET     /showUser                    controllers.Login.status()
 GET     /oauthCallback               controllers.Login.oauthCallback()

--- a/conf/routes
+++ b/conf/routes
@@ -6,8 +6,9 @@ GET     /                           controllers.Application.index()
 
 GET     /login                       controllers.Application.login(returnUrl: String)
 
-GET     /desktop-login               controllers.DesktopLogin.desktopLogin()
-GET     /desktopOauthCallback        controllers.DesktopLogin.desktopOauthCallback()
+GET     /desktop/login               controllers.DesktopLogin.desktopLogin()
+GET     /desktop/showUser            controllers.DesktopLogin.authStatus()
+GET     /desktop/oauthCallback        controllers.DesktopLogin.desktopOauthCallback()
 
 GET     /showUser                    controllers.Login.status()
 GET     /oauthCallback               controllers.Login.oauthCallback()
@@ -18,12 +19,12 @@ GET     /emergency/reissue           controllers.Emergency.reissue()
 GET     /emergency/reissue-disabled  controllers.Emergency.reissueDisabled()
 GET     /emergency/request-cookie    controllers.Emergency.requestCookieLink()
 GET     /emergency/new-cookie/:token controllers.Emergency.issueNewCookie(token)
-+ NOCSRF
++NOCSRF
 POST    /emergency/send-cookie-link  controllers.Emergency.sendCookieLink()
 
-+ NOCSRF
++NOCSRF
 POST    /switches/emergency/on       controllers.SwitchesController.emergencyOn()
-+ NOCSRF
++NOCSRF
 POST    /switches/emergency/off      controllers.SwitchesController.emergencyOff()
 GET     /switches                    controllers.SwitchesController.index()
 


### PR DESCRIPTION
adds a new controller and group of endpoints for facilitating auth for non-browser apps

## Context 

currently various flexible-content apis made available to machines and non-browser user agents (namely incopy & indesign plugins & scripts) are provided access purely through network rules. this saved having to manage stronger authentication systems but meant that clients had to be logged into the privileged networks to gain access, which is a problem when that network sometimes goes down, or more generally we move to be a less office-centric business. As such, we want to make those APIs available on the wider internet, which means we need to address the authentication problem.

Machine clients are no problem; we already have a scheme for sending requests with HMAC: https://github.com/guardian/hmac-headers. However this is a poor solution for human users using non-browser user agents - the secrets to enable HMAC will generally be long-lived and really shouldn't be shared between all the users' systems. It would be much better to provide access based on proof of Google account status, just like regular panda. 

After discussing that idea back and forth we realised that there's nothing super special about the panda cookies - they're a blob of data with a trusted signature placed in the user's cookies since browsers will pass them around as we want. We have control of all the user agents (scripts) we want to authenticate, so if the scripts can start an authentication flow (ie. open a browser on a webpage), and receive a request from the web browser, we can produce a slightly altered sign in flow which instead of redirecting to a website with the cookie set, could redirect to a custom url scheme where the scripts can receive and store the token for later requests, and the APIs can verify that token.

## Implementation

Rather than produce a new tool to perform this sign in flow, we decided that it would make sense to add this to login.gutools, which is already set up to provide token generation for tools which cannot do so themselves.

There's nothing directly stopping user agents sending the generated token inside a cookie header to pretend to be a web browser, but that seemed a bad idea, so instead the intention is for user agents to send the requests inside the `Authorization` header, with the scheme name `GU-desktop-panda` (TBD).

I've generated a new set of keypairs for each stage for the desktop login system, just to be safe.

Generated tokens are passed back to scripts using the existing url handler scheme used by our print prod scripts, the `gnm://` prefix, passing off to the `token` handler. This will insert tokens into the user's keychain with the appropriate permissions set, and then scripts connecting to integration will fetch the token from that keychain entry.

Otherwise it's mostly the same as existing panda - pull down a settings file from the usual S3 bucket, send the user to Google for OAuth, receive OAuth callbacks and redirect... 