### PR TITLE
Update docs to use non-deprecated method

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Central Production will send comms to all users letting them know what to do:
 >   https://login.gutools.co.uk/emergency/request-cookie
 
 In the event that Gmail is also down and users can't receive emails, you can fish out a login token to send to them by other means.
-You will need `composer` Janus credentials to run this script. Once they have visited the `/emergency/request-cookie` endpoint:
+You will need `composer` Janus credentials, or potentially regular IAM crediations (aka break-glass credentials) if you cannot log in
+to Janus. Once they have visited the `/emergency/request-cookie` endpoint:
 
 ```
 ./script/get-emergency-login-link firstname.lastname@guardian.co.uk

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Users that can change the switch will have their userId and a password hash stor
 ```
 sbt console
 import com.github.t3hnar.bcrypt._
-"[password-value]".bcrypt
+"[password-value]".boundedBcrypt
 ```
 Add a new item to the Composer DynamoDB table `login.gutools-emergency-access-[STAGE]` containing the userId and password hash.
 


### PR DESCRIPTION
## What does this change?

`.bcrypt` is depreacted. This is a particular problem for us since we treat warnings as errors, so the documentation on password hashing no longer works.

Here is the error:
```
warning: method bcrypt in class BCryptStrOps is deprecated (since 4.3.0): Use boundedBcrypt instead.
       More information at https://github.com/t3hnar/scala-bcrypt/issues/23
```

Also updates the README to acknowledge that if Google auth is down, Janus may be unavailable.
