### PR TITLE
update to newly agreed gu-panda:// scheme

### DIFF
--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -57,7 +57,7 @@ class DesktopLogin(
 
       if (validateUser(authedUserData)) {
         val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.privateKey)
-        Redirect(s"gnm://auth/token/${URLEncoder.encode(token, "UTF-8")}/stage/${deps.config.stage.toLowerCase}")
+        Redirect(s"gu-panda://desktop?token=${URLEncoder.encode(token, "UTF-8")}&stage=${deps.config.stage.toLowerCase}")
           .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
       } else {
         showUnauthedMessage(invalidUserMessage(claimedAuth))


### PR DESCRIPTION
We've changed our mind and no longer want these to be handled by the same app as the other gnm:// links... 

Instead we've decided to pass it to a new app, which means a new scheme (we've picked gu-panda://) and an opportunity to use a more sensible parameter scheme (ie. using query params instead of path segments)