### PR TITLE
add a new `/desktop/loginRedirect` endpoint which performs a client-side redirect to `/desktop/login`

### DIFF
--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -19,6 +19,12 @@ class DesktopLogin(
 
   implicit private val ec: ExecutionContext = deps.executionContext
 
+
+  def clientSideRedirectToDesktopLogin = Action {
+    val desktopLoginUrl = controllers.routes.DesktopLogin.desktopLogin().url
+    Ok(views.html.clientSideRedirectToLogin(desktopLoginUrl))
+  }
+
   def desktopLogin: Action[AnyContent] = Action.async { implicit request =>
     val antiForgeryToken = OAuth.generateAntiForgeryToken()
     OAuth.redirectToOAuthProvider(antiForgeryToken, None)(ec, request, wsClient) map { _.withSession {

--- a/app/views/clientSideRedirectToLogin.scala.html
+++ b/app/views/clientSideRedirectToLogin.scala.html
@@ -1,0 +1,16 @@
+@(loginUrl: String)
+<html>
+    <head>
+        <title>
+            Redirecting to login...
+        </title>
+        <script>
+            setTimeout(function() {
+                window.location.href = "@loginUrl";
+            }, 250);
+        </script>
+    </head>
+    <body>
+        <h1>Redirecting to login...</h1>
+    </body>
+</html>

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,7 @@ GET     /                           controllers.Application.index()
 
 GET     /login                       controllers.Application.login(returnUrl: String)
 
+GET     /desktop/loginRedirect       controllers.DesktopLogin.clientSideRedirectToDesktopLogin()
 GET     /desktop/login               controllers.DesktopLogin.desktopLogin()
 GET     /desktop/showUser            controllers.DesktopLogin.authStatus()
 GET     /desktop/oauthCallback       controllers.DesktopLogin.desktopOauthCallback()


### PR DESCRIPTION
…to hopefully work around an issue when opening Chrome for the first time with an url that ultimately redirects back to an url with 'custom scheme'