### PR TITLE
Upgrade to panda v4

### DIFF
--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -27,7 +27,7 @@ class DesktopLogin(
 
   def desktopLogin: Action[AnyContent] = Action.async { implicit request =>
     val antiForgeryToken = OAuth.generateAntiForgeryToken()
-    OAuth.redirectToOAuthProvider(antiForgeryToken, None)(ec, request, wsClient) map { _.withSession {
+    OAuth.redirectToOAuthProvider(antiForgeryToken, None)(ec) map { _.withSession {
       request.session + (ANTI_FORGERY_KEY -> antiForgeryToken)
     }}
   }

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositori
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "3.0.1",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.1",
   "com.gu.play-secret-rotation" %% "play-v30" % "7.1.1",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
This PR upgrades our [pan-domain-authentication](https://github.com/guardian/pan-domain-authentication) (panda) libraries to v4, which is a vital step towards our plan to improve key rotation.

### How to review and test
[Check](https://riffraff.gutools.co.uk/deployment/history?projectName=editorial-tools%3Alogin&stage=CODE&pageSize=20&page=1) if this branch is deployed to CODE. If not, deploy to [CODE](https://login.code.dev-gutools.co.uk/)[^1].

We want to test that the Panda library can: 
(1) verify valid Panda cookies
(2) issue Panda cookies through OAuth
(3) issue cookies that work 'pan domain', i.e. across tools on the same domain (in this case, dev-gutools.co.uk)
(4) **but wait this time there's more!** login.gutools logs other tools in with panda (which may not be able to issue panda cookies themselves) - we need to test a tool which depends on login.gutools

Choose another tool on the same domain to test with. For example, [Composer CODE](https://composer.code.dev-gutools.co.uk/).

### 1. Verification
Open the other tool. If the tool asks you to login through Google Auth, log in. This will issue you a Panda cookie. If you are not directed to Google Auth, you already have a Panda cookie to test with.

Open login.gutools on an authed endpoint, e.g. https://login.code.dev-gutools.co.uk/showUser. You should see login.gutools as normal. Check your network tab - you should see **no** requests to OAuth.

This should give confidence that Panda has verified your cookie.

### 2. Issuing
Open login.gutools again on an authed endpoint, e.g. https://login.code.dev-gutools.co.uk/showUser. 

In the DevTools, under the Application panel, you can find the Panda cookie. It has the name `gutoolsAuth-assym`:
![image](https://github.com/user-attachments/assets/58d54450-310d-4552-ac10-d8046145211f)

Delete the cookie, and refresh the page. You should see login.gutools as normal[^2]. Check the network tab. You should see a request to OAuth. 

Check the Application tab again. You should have a new `gutoolsAuth-assym` cookie - though it looks very similar to the old one!

This should give confidence that Panda has issued you a cookie.

### 3. Pan-Domain
Open the other tool. 

You should see the tool as normal. Check your network tab - you should see **no** requests to OAuth.

This should give confidence that your new cookie (issued by login.gutools) works across the domain[^3].

### 4. Dependant tools
Open a tool that depends on login.gutools, e.g. [GuDocs CODE](https://gudocs.code.dev-gutools.co.uk/). Does it 'issue' and 'verify' cookies as above? If you delete the panda cookie, and refresh, does it make a successful request to login.gutools and show you GuDocs? Does this cookie work pan-domain?

[^1]: You can also test this locally, but you will need to test with another local tool. CODE and local are scoped to different domains (`.code.dev-gutools.co.uk` and `.local.dev-gutools.co.uk`).
[^2]: If you are redirected to Google Auth, then your Auth session with Google may have expired. This is fine. Log in through Google Auth and repeat the test. If it _keeps_ directing you to Google Auth, then there may be an issue!
[^3]: If you check the Application tab in the other tool, you might find the cookie has changed! This is still the same cookie, but it has been slightly edited. Each tool you access with the cookie will be added to the cookie's `authedIn` list. The edits are hard to see as the cookie is encrypted. If you check the first tool again, you will see the cookie has stabilised.