### PR TITLE
Upgrade to Panda v7 - support key rotation

### DIFF
--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -36,7 +36,7 @@ class DesktopLogin(
     request.headers.get(AUTHORIZATION) match {
       case Some(s"GU-Desktop-Panda $token") =>
         PanDomain.authStatus(token,
-          publicKey = panDomainSettings.settings.signingKeyPair.getPublic,
+          verification = panDomainSettings.settings.signingAndVerification,
           validateUser = PanDomain.guardianValidation,
           apiGracePeriod = 9.hours.toMillis,
           system = panDomainSettings.system,
@@ -64,7 +64,7 @@ class DesktopLogin(
 
 
       if (validateUser(authedUserData)) {
-        val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.signingKeyPair.getPrivate)
+        val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.signingAndVerification)
         Redirect(s"gu-panda://desktop?token=${URLEncoder.encode(token, "UTF-8")}&stage=${deps.config.stage.toLowerCase}")
           .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
       } else {

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ resolvers ++= Resolver.sonatypeOssRepos("releases")
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "5.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.1",
   "com.gu.play-secret-rotation" %% "play-v30" % "7.1.1",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,


### PR DESCRIPTION
This upgrades Panda from v5 to v7, allowing us to [perform key rotation](https://github.com/guardian/pan-domain-authentication/pull/150).

As login.gutools.co.uk is pretty special user of Panda, the upgrade is slightly more involved than other upgrades (eg https://github.com/guardian/atom-workshop/pull/361):

* Panda v6:
  * https://github.com/guardian/pan-domain-authentication/pull/152 means the `CookieUtils.generateCookieData()` method now communicates errors with `CookieResult` values containing `CookieIntegrityFailure`, rather than exceptions.
  * https://github.com/guardian/pan-domain-authentication/pull/151 introduced the new `S3BucketLoader` abstraction, which simplifies constructing a `PanDomainAuthSettingsRefresher` and means that Panda is no longer _tied_ to AWS SDK v1 - an alternative AWS SDK v2 implementation of `S3BucketLoader` could be introduced.
* Panda v7:
  * https://github.com/guardian/pan-domain-authentication/pull/150 means that code shouldn't directly reference private or public keys anymore (eg do not reference `settings.signingKeyPair`). Instead, use `settings.signingAndVerification` or `publicSettings.verification`. Note also that `publicSettings.publicKey` was previously optional, and `publicSettings.verification` is not.

This PR sits on top of:

* https://github.com/guardian/login.gutools/pull/82