### PR TITLE
Update to Panda v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 /.project
 /.settings
 /RUNNING_PID
+.bsp/

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -36,7 +36,7 @@ class DesktopLogin(
     request.headers.get(AUTHORIZATION) match {
       case Some(s"GU-Desktop-Panda $token") =>
         PanDomain.authStatus(token,
-          publicKey = panDomainSettings.settings.publicKey,
+          publicKey = panDomainSettings.settings.signingKeyPair.getPublic,
           validateUser = PanDomain.guardianValidation,
           apiGracePeriod = 9.hours.toMillis,
           system = panDomainSettings.system,
@@ -64,7 +64,7 @@ class DesktopLogin(
 
 
       if (validateUser(authedUserData)) {
-        val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.privateKey)
+        val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.signingKeyPair.getPrivate)
         Redirect(s"gu-panda://desktop?token=${URLEncoder.encode(token, "UTF-8")}&stage=${deps.config.stage.toLowerCase}")
           .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
       } else {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "login"
 
 version := "1.0.0"
 
-scalaVersion := "2.13.12"
+scalaVersion := "2.13.14"
 scalacOptions := Seq(
   "-unchecked",
   "-deprecation",
@@ -16,12 +16,12 @@ scalacOptions := Seq(
 val awsSdkVersion = "1.12.130"
 val awsSdkVersionV2 = "2.17.101"
 
-resolvers += "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
+resolvers ++= Resolver.sonatypeOssRepos("releases")
 
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "5.0.0",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.1",
   "com.gu.play-secret-rotation" %% "play-v30" % "7.1.1",
   "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.6
+sbt.version=1.10.1


### PR DESCRIPTION
Upgrading to Panda [v5.0.0](https://github.com/guardian/pan-domain-authentication/releases/tag/v5.0.0) is a pretty minor change, but due to https://github.com/guardian/pan-domain-authentication/pull/147 and https://github.com/guardian/pan-domain-authentication/issues/153, there is one code change required:

* `settings.privateKey` becomes `settings.signingKeyPair.getPrivate`

Similarly to https://github.com/guardian/s3-upload/pull/59, I've also bumped the Scala & sbt versions a tiny bit, added a gitignore line, tiny things!


### Testing

This has been [successfully deployed](https://riffraff.gutools.co.uk/deployment/view/7cbc6b4c-fb9e-4fd3-8bde-eda9d4dd430f) to https://login.code.dev-gutools.co.uk/, and I've verified that it still works by using CODE s3-uploader, which redirects to login.code.dev-gutools.co.uk to regenerate the `gutoolsAuth-assym` cookie:

https://github.com/user-attachments/assets/77d1660f-e79b-4ebc-b449-034551904164

