### PR TITLE
Set code owner to workflow-and-collaboration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/workflow-and-collaboration


### PR DESCRIPTION
## What does this change?

The [Workflow and Collaboration team](https://github.com/orgs/guardian/teams/workflow-and-collaboration) are [taking ownership of panda](https://github.com/guardian/pan-domain-authentication/pull/189), and we feel it makes sense for us to also take ownership of this repository as it is so closely related. This PR therefore sets the code owner for this repository to be us.

## How to test

- confirm that github flags the code owners file as valid in the UI
- after merge, test that opening a new PR requests a code owner review from Workflow and Collaboration