### PR TITLE
Bump AWS SDK v2 to fix vulnerability on netty-codec-http2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions := Seq(
 // We must include both AWS SDK V1 and V2 to enable the use of latest
 // Scanamo whilst avoiding overhauling the whole app to V2.
 val awsSdkVersion = "1.12.130"
-val awsSdkVersionV2 = "2.17.101"
+val awsSdkVersionV2 = "2.31.19"
 
 resolvers ++= Resolver.sonatypeOssRepos("releases")
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This pull request bumps the AWS SDK v2 to the latest version (2.31.19), which updates the transitive dependency on netty-codec-http2 to version 4.1.118.  This netty version should have fixed the [vulnerability](https://github.com/advisories/GHSA-xpw8-rcwv-8f8p) found in the older versions (prior to 4.1.100).

## How to test

In Incognito window, I opened "https://login.code.dev-gutools.co.uk/login?returnUrl=https://composer.code.dev-gutools.co.uk/".  It forwarded the browser to Google sign-in.  After sign-in, it redirected me to the Composer CODE.

I also opened "https://login.code.dev-gutools.co.uk/whoami" and it could return my account info.