### PR TITLE
Upgrade AWS SDK to V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ target
 /.settings
 /RUNNING_PID
 .bsp/
+.bloop
+/.metals
+/.vscode

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -9,12 +9,9 @@ import scala.concurrent.Future
 class AppComponents(context: Context) extends LoginControllerComponents(context, new AWS()) {
   override def config = LoginConfig.forStage(asgTags.map(_.stage))
 
-  def s3BucketLoaderForAwsSdkV2(bucketName: String): S3BucketLoader = (key: String) =>
-    aws.s3SyncClient.getObject(_.bucket(bucketName).key(key))
-
   override val switches = new Switches(config, aws.s3AsyncClient)
 
-  private val s3BucketLoader: S3BucketLoader = s3BucketLoaderForAwsSdkV2("pan-domain-auth-settings")
+  private val s3BucketLoader: S3BucketLoader =aws.PandaHelpers.forAwsSdkV2(aws.s3SyncClient, "pan-domain-auth-settings")
 
   private lazy val panDomainSettings: PanDomainAuthSettingsRefresher = PanDomainAuthSettingsRefresher(
     domain = config.domain,

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -11,7 +11,7 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
 
   override val switches = new Switches(config, aws.s3AsyncClient)
 
-  private val s3BucketLoader: S3BucketLoader =aws.PandaHelpers.forAwsSdkV2(aws.s3SyncClient, "pan-domain-auth-settings")
+  private val s3BucketLoader: S3BucketLoader = aws.PandaHelpers.forAwsSdkV2(aws.s3SyncClient, "pan-domain-auth-settings")
 
   private lazy val panDomainSettings: PanDomainAuthSettingsRefresher = PanDomainAuthSettingsRefresher(
     domain = config.domain,

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -11,7 +11,7 @@ class AppComponents(context: Context) extends LoginControllerComponents(context,
 
   override val switches = new Switches(config, aws.s3AsyncClient)
 
-  private val s3BucketLoader: S3BucketLoader = aws.PandaHelpers.forAwsSdkV2(aws.s3SyncClient, "pan-domain-auth-settings")
+  private val s3BucketLoader: S3BucketLoader = S3BucketLoader.forAwsSdkV2(aws.s3SyncClient, "pan-domain-auth-settings")
 
   private lazy val panDomainSettings: PanDomainAuthSettingsRefresher = PanDomainAuthSettingsRefresher(
     domain = config.domain,

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -19,7 +19,7 @@ import scala.util.Try
 case class InstanceTags(stack: String, app: String, stage: String)
 
 class AWS {
-  val region= Region.EU_WEST_1
+  val region = Region.EU_WEST_1
   val profile = "composer"
 
 

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -1,16 +1,13 @@
 package config
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, SystemPropertiesCredentialsProvider}
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, DescribeAutoScalingInstancesRequest}
-import com.amazonaws.services.autoscaling.{AmazonAutoScaling, AmazonAutoScalingClientBuilder}
-import com.amazonaws.services.simpleemail.{AmazonSimpleEmailService, AmazonSimpleEmailServiceClientBuilder}
-import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
+import software.amazon.awssdk.services.autoscaling.model.{DescribeAutoScalingGroupsRequest, DescribeAutoScalingInstancesRequest}
+import software.amazon.awssdk.services.autoscaling.AutoScalingClient
+import software.amazon.awssdk.services.ses.SesClient
+import software.amazon.awssdk.services.ssm.SsmClient
 import com.amazonaws.util.EC2MetadataUtils
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider => EnvironmentVariableCredentialsProviderV2, InstanceProfileCredentialsProvider => InstanceProfileCredentialsProviderV2, ProfileCredentialsProvider => ProfileCredentialsProviderV2}
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, SystemPropertyCredentialsProvider, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, ProfileCredentialsProvider}
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
-import software.amazon.awssdk.regions.{Region => RegionV2}
+import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Client}
 
@@ -19,29 +16,23 @@ import scala.jdk.CollectionConverters._
 case class InstanceTags(stack: String, app: String, stage: String)
 
 class AWS {
-  val region = Region.getRegion(Regions.EU_WEST_1).getName
+  val region= Region.EU_WEST_1
   val profile = "composer"
 
-  val composerAwsCredentialsProvider = new AWSCredentialsProviderChain(
-    new EnvironmentVariableCredentialsProvider(),
-    new SystemPropertiesCredentialsProvider(),
-    InstanceProfileCredentialsProvider.getInstance(),
-    new ProfileCredentialsProvider(profile)
-  )
-
-  val asgClient: AmazonAutoScaling = AmazonAutoScalingClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
-  val ssmClient: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
-  val sesClient: AmazonSimpleEmailService = AmazonSimpleEmailServiceClientBuilder.standard().withRegion(region).withCredentials(composerAwsCredentialsProvider).build()
 
   private val v2CredentialsProvider = AwsCredentialsProviderChain.builder.credentialsProviders(
-    ProfileCredentialsProviderV2.builder.profileName(profile).build,
-    InstanceProfileCredentialsProviderV2.builder.asyncCredentialUpdateEnabled(false).build,
-    EnvironmentVariableCredentialsProviderV2.create()
+    ProfileCredentialsProvider.builder.profileName(profile).build,
+    InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
+    SystemPropertyCredentialsProvider.create(),
+    EnvironmentVariableCredentialsProvider.create()
   ).build
 
-  private def setup[B <: AwsClientBuilder[B, _]](builder: B): B =
-    builder.credentialsProvider(v2CredentialsProvider).region(RegionV2.EU_WEST_1)
+  val asgClient: AutoScalingClient = AutoScalingClient.builder.region(region).credentialsProvider(v2CredentialsProvider).build()
+  val ssmClient: SsmClient = SsmClient.builder().region(region).credentialsProvider(v2CredentialsProvider).build()
+  val sesClient: SesClient =  SesClient.builder().region(region).credentialsProvider(v2CredentialsProvider).build()
 
+  private def setup[B <: AwsClientBuilder[B, _]](builder: B): B =
+    builder.credentialsProvider(v2CredentialsProvider).region(region)
   val s3SyncClient: S3Client = setup(S3Client.builder).build()
   val s3AsyncClient: S3AsyncClient = setup(S3AsyncClient.builder).build()
   val dynamoDbClient: DynamoDbClient = setup(DynamoDbClient.builder).build()
@@ -62,23 +53,26 @@ class AWS {
     }
   }
 
+
+
   private def getAutoscalingGroupName(instanceId: String): Option[String] = {
-    val request = new DescribeAutoScalingInstancesRequest().withInstanceIds(instanceId)
+    val request = DescribeAutoScalingInstancesRequest.builder.instanceIds(instanceId).build()
     val response = asgClient.describeAutoScalingInstances(request)
 
-    val instance = response.getAutoScalingInstances.asScala.headOption
-    instance.map(_.getAutoScalingGroupName)
+    val instance = response.autoScalingInstances.asScala.headOption
+    instance.map(_.autoScalingGroupName)
   }
 
   private def getTags(autoscalingGroupName: String): Option[Map[String, String]] = {
-    val request = new DescribeAutoScalingGroupsRequest().withAutoScalingGroupNames(autoscalingGroupName)
+    val request = DescribeAutoScalingGroupsRequest.builder.autoScalingGroupNames(autoscalingGroupName).build()
     val response = asgClient.describeAutoScalingGroups(request)
 
-    val maybeGroup = response.getAutoScalingGroups.asScala.headOption
+    val maybeGroup = response.autoScalingGroups.asScala.headOption
+
     maybeGroup.map {
-      _.getTags
+      _.tags
         .asScala
-        .map { t => t.getKey -> t.getValue }
+        .map { t => t.key -> t.value }
         .toMap
     }
   }

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -30,24 +30,14 @@ class AWS {
     EnvironmentVariableCredentialsProvider.create()
   ).build
 
-  val asgClient: AutoScalingClient = AutoScalingClient.builder.region(region).credentialsProvider(v2CredentialsProvider).build()
-  val ssmClient: SsmClient = SsmClient.builder().region(region).credentialsProvider(v2CredentialsProvider).build()
-  val sesClient: SesClient =  SesClient.builder().region(region).credentialsProvider(v2CredentialsProvider).build()
-
-  object PandaHelpers {
-    def forAwsSdkV2(anonS3Client: S3Client, bucket: String): S3BucketLoader =
-      (key: String) => {
-        anonS3Client.getObject(
-          GetObjectRequest.builder().bucket(bucket).key(key).build()
-        )
-      }
-  }
-
   private def setup[B <: AwsClientBuilder[B, _]](builder: B): B =
     builder.credentialsProvider(v2CredentialsProvider).region(region)
   val s3SyncClient: S3Client = setup(S3Client.builder).build()
   val s3AsyncClient: S3AsyncClient = setup(S3AsyncClient.builder).build()
   val dynamoDbClient: DynamoDbClient = setup(DynamoDbClient.builder).build()
+  val asgClient: AutoScalingClient = setup(AutoScalingClient.builder).build()
+  val ssmClient: SsmClient = setup(SsmClient.builder).build()
+  val sesClient: SesClient = setup(SesClient.builder).build()
 
   def readTags(): Option[InstanceTags] = {
     // We read tags from the AutoScalingGroup rather than the instance itself to avoid problems where the

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -4,7 +4,7 @@ import software.amazon.awssdk.services.autoscaling.model.{DescribeAutoScalingGro
 import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.ses.SesClient
 import software.amazon.awssdk.services.ssm.SsmClient
-import com.amazonaws.util.EC2MetadataUtils
+import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils
 import com.gu.pandomainauth.S3BucketLoader
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, ProfileCredentialsProvider, SystemPropertyCredentialsProvider}
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Client}
 
 import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 case class InstanceTags(stack: String, app: String, stage: String)
 
@@ -52,7 +53,7 @@ class AWS {
     // We read tags from the AutoScalingGroup rather than the instance itself to avoid problems where the
     // tags have not been applied to the instance before we start up (they are eventually consistent)
     for {
-      instanceId <- Option(EC2MetadataUtils.getInstanceId)
+      instanceId <-  Try(EC2MetadataUtils.getInstanceId).toOption
       asg <- getAutoscalingGroupName(instanceId)
       tags <- getTags(asg)
 

--- a/app/config/AWS.scala
+++ b/app/config/AWS.scala
@@ -5,10 +5,12 @@ import software.amazon.awssdk.services.autoscaling.AutoScalingClient
 import software.amazon.awssdk.services.ses.SesClient
 import software.amazon.awssdk.services.ssm.SsmClient
 import com.amazonaws.util.EC2MetadataUtils
-import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, SystemPropertyCredentialsProvider, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, ProfileCredentialsProvider}
+import com.gu.pandomainauth.S3BucketLoader
+import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, ProfileCredentialsProvider, SystemPropertyCredentialsProvider}
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.{S3AsyncClient, S3Client}
 
 import scala.jdk.CollectionConverters._
@@ -30,6 +32,15 @@ class AWS {
   val asgClient: AutoScalingClient = AutoScalingClient.builder.region(region).credentialsProvider(v2CredentialsProvider).build()
   val ssmClient: SsmClient = SsmClient.builder().region(region).credentialsProvider(v2CredentialsProvider).build()
   val sesClient: SesClient =  SesClient.builder().region(region).credentialsProvider(v2CredentialsProvider).build()
+
+  object PandaHelpers {
+    def forAwsSdkV2(anonS3Client: S3Client, bucket: String): S3BucketLoader =
+      (key: String) => {
+        anonS3Client.getObject(
+          GetObjectRequest.builder().bucket(bucket).key(key).build()
+        )
+      }
+  }
 
   private def setup[B <: AwsClientBuilder[B, _]](builder: B): B =
     builder.credentialsProvider(v2CredentialsProvider).region(region)

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -8,7 +8,7 @@ import play.api.mvc.{Action, AnyContent}
 
 import java.net.URLEncoder
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.DurationInt
+import java.time.Duration
 
 class DesktopLogin(
   deps: LoginControllerComponents,
@@ -35,7 +35,7 @@ class DesktopLogin(
         PanDomain.authStatus(token,
           verification = panDomainSettings.settings.signingAndVerification,
           validateUser = PanDomain.guardianValidation,
-          apiGracePeriod = 9.hours.toMillis,
+          apiGracePeriod = Duration.ofHours(9),
           system = panDomainSettings.system,
           cacheValidation = false,
           forceExpiry = false

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,12 +1,12 @@
 package controllers
 
-import software.amazon.awssdk.services.ses.SesClient
 import com.github.nscala_time.time.Imports._
 import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
 import com.gu.pandomainauth.service.CookieUtils
 import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, PublicSettings}
 import play.api.mvc._
 import services.NewCookieIssue
+import software.amazon.awssdk.services.ses.SesClient
 import utils._
 
 import scala.util.Random

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
+import software.amazon.awssdk.services.ses.SesClient
 import com.github.nscala_time.time.Imports._
 import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
 import com.gu.pandomainauth.service.CookieUtils
@@ -15,7 +15,7 @@ import scala.util.control.NonFatal
 class Emergency(
    loginPublicSettings: PublicSettings,
    deps: LoginControllerComponents,
-   sesClient: AmazonSimpleEmailService,
+   sesClient: SesClient,
    panDomainSettings: PanDomainAuthSettingsRefresher
 ) extends LoginController(deps, panDomainSettings) with Loggable {
 

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -9,6 +9,8 @@ import services.NewCookieIssue
 import software.amazon.awssdk.services.ses.SesClient
 import utils._
 
+import java.time.Instant.now
+import java.time.Duration
 import scala.util.Random
 import scala.util.control.NonFatal
 
@@ -19,7 +21,7 @@ class Emergency(
    panDomainSettings: PanDomainAuthSettingsRefresher
 ) extends LoginController(deps, panDomainSettings) with Loggable {
 
-  private val cookieLifetime = 1.day
+  private val cookieLifetime = Duration.ofDays(1) // 1.day
 
   def reissueDisabled: Action[AnyContent] = Action {
     Ok(views.html.emergency.reissueDisabled())
@@ -36,7 +38,7 @@ class Emergency(
         unauthorised(s"Invalid existing session, could not log you in: $tokenIntegrityFailure", reissueTopic)
       , authenticatedUser =>
         if (validateUser(authenticatedUser)) {
-          val authCookie = generateCookie(authenticatedUser.copy(expires = (DateTime.now() + cookieLifetime).getMillis))
+          val authCookie = generateCookie(authenticatedUser.copy(expires = (now().plus(cookieLifetime))))
           Ok(views.html.emergency.reissueSuccess()).withCookies(authCookie)
         } else unauthorised("Only Guardian email addresses with two-factor auth are supported.", reissueTopic)
     )).getOrElse {
@@ -85,7 +87,7 @@ class Emergency(
 
       deps.tokenDBService.expireCookieIssue(newCookieIssue)
 
-      val expires = (DateTime.now() + cookieLifetime).getMillis
+      val expires = now().plus(cookieLifetime)
       val names = newCookieIssue.email.split("\\.")
       val firstName = names(0).capitalize
       val lastName = names(1).split("@")(0).capitalize

--- a/app/controllers/LoginComponents.scala
+++ b/app/controllers/LoginComponents.scala
@@ -5,7 +5,7 @@ import com.github.t3hnar.bcrypt._
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.pandomainauth.{PanDomain, PanDomainAuthSettingsRefresher}
-import com.gu.play.secretrotation.aws.parameterstore.{AwsSdkV1, SecretSupplier}
+import com.gu.play.secretrotation.aws.parameterstore
 import com.gu.play.secretrotation.{RotatingSecretComponents, SnapshotProvider, TransitionTiming}
 import config._
 import play.api.ApplicationLoader.Context
@@ -44,10 +44,10 @@ abstract class LoginControllerComponents(
     val app = asgTags.map(_.app).getOrElse("login")
     val stage = asgTags.map(_.stage).getOrElse("DEV")
 
-    new SecretSupplier(
+    new parameterstore.SecretSupplier(
       TransitionTiming(usageDelay = Duration.ofMinutes(3), overlapDuration = Duration.ofHours(2)),
       parameterName = s"/$stack/$app/$stage/play.http.secret.key",
-      AwsSdkV1(aws.ssmClient)
+      parameterstore.AwsSdkV2(aws.ssmClient)
     )
   }
 }

--- a/app/utils/Mailer.scala
+++ b/app/utils/Mailer.scala
@@ -1,11 +1,15 @@
 package utils
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService
-import com.amazonaws.services.simpleemail.model._
+import software.amazon.awssdk.services.ses.SesClient
+import software.amazon.awssdk.services.ses.model._
+
 import config.LoginConfig
 
-class SES(sesClient: AmazonSimpleEmailService, loginConfig: LoginConfig) {
+class SES(sesClient: SesClient, loginConfig: LoginConfig) {
+  def buildContent(data: String) = Content.builder().charset("UTF-8").data(data).build()
+
   def sendCookieEmail(token: String, sendTo: String): Unit = {
+
 
     val uri = loginConfig.tokenReissueUri
 
@@ -25,15 +29,15 @@ class SES(sesClient: AmazonSimpleEmailService, loginConfig: LoginConfig) {
          |</div>
        """.stripMargin
 
-    sesClient.sendEmail(new SendEmailRequest()
-      .withDestination(new Destination().withToAddresses(sendTo))
-      .withMessage(new Message()
-        .withSubject(new Content("[emergency login] Guardian Editorial Tools - new cookie link"))
-        .withBody(new Body().withHtml(new Content(emailBody)))
-      )
-      .withSource(loginConfig.emailSettings("from"))
-      .withReplyToAddresses(loginConfig.emailSettings("replyTo"))
-    )
 
+    sesClient.sendEmail( SendEmailRequest.builder()
+      .destination(Destination.builder().toAddresses(sendTo).build())
+      .message(Message.builder()
+        .subject(buildContent("[emergency login] Guardian Editorial Tools - new cookie link"))
+        .body(Body.builder().html(buildContent(emailBody)).build()).build()
+      )
+      .source(loginConfig.emailSettings("from"))
+      .replyToAddresses(loginConfig.emailSettings("replyTo")).build()
+    )
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -13,16 +13,16 @@ scalacOptions := Seq(
 
 // We must include both AWS SDK V1 and V2 to enable the use of latest
 // Scanamo whilst avoiding overhauling the whole app to V2.
-val awsSdkVersion = "1.12.130"
 val awsSdkVersionV2 = "2.34.5"
 val jacksonVersion = "2.19.2"
+val playSecretRotationVersion = "15.1.0"
 
 libraryDependencies ++= Seq(
   jdbc,
   ws,
   "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
-  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.1",
-  "com.gu.play-secret-rotation" %% "play-v30" % "7.1.1",
+  "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % playSecretRotationVersion ,
+  "com.gu.play-secret-rotation" %% "play-v30" % playSecretRotationVersion ,
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "8.2.0",
   "software.amazon.awssdk" % "ec2" % awsSdkVersionV2,
   "software.amazon.awssdk" % "cloudwatch" % awsSdkVersionV2,

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions := Seq(
 // We must include both AWS SDK V1 and V2 to enable the use of latest
 // Scanamo whilst avoiding overhauling the whole app to V2.
 val awsSdkVersion = "1.12.130"
-val awsSdkVersionV2 = "2.31.19"
+val awsSdkVersionV2 = "2.34.5"
 val jacksonVersion = "2.19.2"
 
 libraryDependencies ++= Seq(
@@ -24,11 +24,12 @@ libraryDependencies ++= Seq(
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "7.1.1",
   "com.gu.play-secret-rotation" %% "play-v30" % "7.1.1",
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "8.2.0",
-  "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-autoscaling" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-ses" % awsSdkVersion,
-  "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
+  "software.amazon.awssdk" % "ec2" % awsSdkVersionV2,
+  "software.amazon.awssdk" % "cloudwatch" % awsSdkVersionV2,
+  "software.amazon.awssdk" % "autoscaling" % awsSdkVersionV2,
+  "software.amazon.awssdk" % "ses" % awsSdkVersionV2,
+  "software.amazon.awssdk" % "ssm" % awsSdkVersionV2, //Needed for Parameter Store?
+  "software.amazon.awssdk" % "kinesis" % awsSdkVersionV2,
   "software.amazon.awssdk" % "dynamodb" % awsSdkVersionV2,
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
   "com.github.nscala-time" %% "nscala-time" % "2.32.0",

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ val playSecretRotationVersion = "15.1.0"
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "7.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "11.0.0-PREVIEW.sh-wsyupgrade-aws-sdk-to-2.2025-09-17T1358.a15b1789",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % playSecretRotationVersion ,
   "com.gu.play-secret-rotation" %% "play-v30" % playSecretRotationVersion ,
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "8.2.0",

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,7 @@ scalacOptions := Seq(
   "-Xfatal-warnings"
 )
 
-
-// We must include both AWS SDK V1 and V2 to enable the use of latest
-// Scanamo whilst avoiding overhauling the whole app to V2.
-val awsSdkVersionV2 = "2.34.5"
+val awsSdkVersionV2 = "2.34.6"
 val jacksonVersion = "2.19.2"
 val playSecretRotationVersion = "15.1.0"
 
@@ -28,7 +25,6 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "cloudwatch" % awsSdkVersionV2,
   "software.amazon.awssdk" % "autoscaling" % awsSdkVersionV2,
   "software.amazon.awssdk" % "ses" % awsSdkVersionV2,
-//  "software.amazon.awssdk" % "ssm" % awsSdkVersionV2, //Needed for Parameter Store?
   "software.amazon.awssdk" % "kinesis" % awsSdkVersionV2,
   "software.amazon.awssdk" % "dynamodb" % awsSdkVersionV2,
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val playSecretRotationVersion = "15.1.0"
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "11.0.0-PREVIEW.sh-wsyupgrade-aws-sdk-to-2.2025-09-17T1358.a15b1789",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "11.0.0",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % playSecretRotationVersion ,
   "com.gu.play-secret-rotation" %% "play-v30" % playSecretRotationVersion ,
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "8.2.0",

--- a/build.sbt
+++ b/build.sbt
@@ -10,14 +10,14 @@ scalacOptions := Seq(
   "-Xfatal-warnings"
 )
 
-val awsSdkVersionV2 = "2.34.6"
+val awsSdkVersionV2 = "2.34.8"
 val jacksonVersion = "2.19.2"
 val playSecretRotationVersion = "15.1.0"
 
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "11.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "12.0.0",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % playSecretRotationVersion ,
   "com.gu.play-secret-rotation" %% "play-v30" % playSecretRotationVersion ,
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "8.2.0",

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "cloudwatch" % awsSdkVersionV2,
   "software.amazon.awssdk" % "autoscaling" % awsSdkVersionV2,
   "software.amazon.awssdk" % "ses" % awsSdkVersionV2,
-  "software.amazon.awssdk" % "ssm" % awsSdkVersionV2, //Needed for Parameter Store?
+//  "software.amazon.awssdk" % "ssm" % awsSdkVersionV2, //Needed for Parameter Store?
   "software.amazon.awssdk" % "kinesis" % awsSdkVersionV2,
   "software.amazon.awssdk" % "dynamodb" % awsSdkVersionV2,
   "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
@@ -36,7 +36,7 @@ libraryDependencies ++= Seq(
   "com.github.t3hnar" %% "scala-bcrypt" % "4.3.0",
   "org.scanamo" %% "scanamo" % "1.0.0-M17",
   "org.scalatest" %% "scalatest" % "3.2.17" % Test,
-  "com.gu" %% "anghammarad-client" % "1.8.1",
+  "com.gu" %% "anghammarad-client" % "6.0.0",
   // Jackson library version addressing vulnerable dependencies
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Upgrade AWS SDK from v1 to v2

AWS SDK for Java v1 will be EOL on 31st December 2025, and has been in Maintenance mode since [31st July 2024](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/). So we have to  upgrade to AWS SDK v2.
[Issue](https://github.com/guardian/login.gutools/issues/103)
## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

1.Deploy the branch to CODE 


2.Open up [login.gutools CODE](https://login.code.dev-gutools.co.uk/)
<img width="733" height="108" alt="image" src="https://github.com/user-attachments/assets/a97aa824-6d3d-4e82-8d40-2b6ba7b58e9b" />

Check if we are receiving a 200 response

<img width="778" height="129" alt="image" src="https://github.com/user-attachments/assets/fe8a1837-3f33-4e0d-aa29-003e0b3871fe" />

3. Open any tool that requires the user to login eg:S3Uploader in a new Incognito window
4. Check if it asking to login 
<img width="332" height="172" alt="image" src="https://github.com/user-attachments/assets/1f64bd2d-417b-4466-8952-4153f7694e98" />


5. On clicking the 'here' link, it should take the user to login page 
<img width="332" height="243" alt="image" src="https://github.com/user-attachments/assets/ab9fe767-2587-44dc-9c26-f8abf990125b" />

6. Enter the details to sign in and check if you are taken to the tool 

<img width="332" height="434" alt="image" src="https://github.com/user-attachments/assets/176ecc9d-edbb-44f8-a14f-a237fb942d86" />

## References

[Upgrading to AWS SDK v2](https://github.com/guardian/maintaining-scala-projects/issues/9)

[LIVE-4941 upgrade AWS SDK to version 2 ](https://github.com/guardian/mobile-apps-api/pull/23310)

## Changes made

- Bump the AWS SDK to v2 in build.sbt
- Update the package and class name of AWS clients  from com.amazonaws.services to software.amazon.awssdk.services
- Change the way we create and use AWS clients according to AWS SDK v2
- Check if we have any Guardian-library-related blockers to removing AWS SDK v1 like https://github.com/guardian/content-api-client-aws/issues/12 - the widely-used content-api-client-aws library needs to add AWS SDK v2 support. and https://github.com/guardian/facia-scala-client/issues/363
- In order to support the change , have upgraded packages like pan-domain to v11, playSecretRotationVersion to v15 , anghammarad-client to v6 
- Copied the changes to bump pan domain tp v11 from this [draft PR] (https://github.com/guardian/login.gutools/pull/102)
