### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-core to version 2.21.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalacOptions := Seq(
 )
 
 val awsSdkVersionV2 = "2.34.8"
-val jacksonVersion = "2.19.2"
+val jacksonVersion = "2.21.1"
 val playSecretRotationVersion = "15.1.0"
 
 libraryDependencies ++= Seq(
@@ -35,7 +35,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "anghammarad-client" % "6.0.0",
   // Jackson library version addressing vulnerable dependencies
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
-  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.21",
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8" % jacksonVersion,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This is to Upgrade com.fasterxml.jackson.core:jackson-core to version 2.21.1

This is to fix the high severity vulnerability raised by dependabot for jackson-core: [Number Length Constraint Bypass in Async Parser Leads to Potential DoS Condition](https://github.com/guardian/login.gutools/security/dependabot/24)

<img width="1379" height="654" alt="image" src="https://github.com/user-attachments/assets/a9786239-07c1-426c-90a1-75d3725dfc0e" />


## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

1. Deploy  the branch to CODE
2. Log in and try to upload an image in a tool like s3-upload 
3. It should succed and should provide a Vanity URL

## Note
There was an error while downloading com.fasterxml.jackson.core:jackson-annotations:2.21.1, so keeping it at 2.21
<img width="1076" height="98" alt="image" src="https://github.com/user-attachments/assets/2e5fd2b4-d2b2-4265-854d-3e001be1a2e2" />

## Images
<img width="1918" height="182" alt="image" src="https://github.com/user-attachments/assets/ac1b8e87-862b-4e95-97d7-4635572f7f71" />

<img width="1918" height="279" alt="image" src="https://github.com/user-attachments/assets/333e9b10-ff47-4c93-95d5-061093d44579" />
