### PR TITLE
Update panda auth to fix bouncy castle vulnerability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ target
 .bloop
 /.metals
 /.vscode
+project/project
+metals.sbt

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -24,8 +24,9 @@ class DesktopLogin(
   }
 
   def desktopLogin: Action[AnyContent] = Action.async { implicit request =>
+    val sessionId = OAuth.generateSessionId()
     val antiForgeryToken = OAuth.generateAntiForgeryToken()
-    OAuth.redirectToOAuthProvider(antiForgeryToken, None)(ec) map { _.withSession {
+    OAuth.redirectToOAuthProvider(sessionId, antiForgeryToken)(ec) map { _.withSession {
       request.session + (ANTI_FORGERY_KEY -> antiForgeryToken)
     }}
   }

--- a/app/controllers/DesktopLogin.scala
+++ b/app/controllers/DesktopLogin.scala
@@ -27,7 +27,7 @@ class DesktopLogin(
     val sessionId = OAuth.generateSessionId()
     val antiForgeryToken = OAuth.generateAntiForgeryToken()
     OAuth.redirectToOAuthProvider(sessionId, antiForgeryToken)(ec) map { _.withSession {
-      request.session + (ANTI_FORGERY_KEY -> antiForgeryToken)
+      request.session + (antiForgeryTokenKey(sessionId) -> antiForgeryToken)
     }}
   }
 
@@ -54,10 +54,13 @@ class DesktopLogin(
   }
 
   def desktopOauthCallback(): Action[AnyContent] = Action.async { implicit request =>
+    val sessionId = OAuth.generateSessionId()
+    val antiForgeryTokenKeyFromSession = antiForgeryTokenKey(sessionId)
+    val loginOriginKeyFromSession = loginOriginKey(sessionId)
     val token =
-      request.session.get(ANTI_FORGERY_KEY).getOrElse(throw new OAuthException("missing anti forgery token"))
+      request.session.get(antiForgeryTokenKeyFromSession).getOrElse(throw new OAuthException("missing anti forgery token"))
 
-    OAuth.validatedUserIdentity(token)(request, deps.executionContext, wsClient).map { claimedAuth =>
+    OAuth.validatedUserIdentity(sessionId, token)(request, deps.executionContext, wsClient).map { claimedAuth =>
       logger.debug("fresh user desktop login")
       val authedUserData = claimedAuth.copy(authenticatingSystem = "login-desktop", multiFactor = checkMultifactor(claimedAuth))
 
@@ -65,7 +68,7 @@ class DesktopLogin(
       if (validateUser(authedUserData)) {
         val token = CookieUtils.generateCookieData(authedUserData, panDomainSettings.settings.signingAndVerification)
         Redirect(s"gu-panda://desktop?token=${URLEncoder.encode(token, "UTF-8")}&stage=${deps.config.stage.toLowerCase}")
-          .withSession(session = request.session - ANTI_FORGERY_KEY - LOGIN_ORIGIN_KEY)
+          .withSession(session = request.session - antiForgeryTokenKeyFromSession - loginOriginKeyFromSession)
       } else {
         showUnauthedMessage(invalidUserMessage(claimedAuth))
       }

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ val playSecretRotationVersion = "15.1.0"
 libraryDependencies ++= Seq(
   jdbc,
   ws,
-  "com.gu" %% "pan-domain-auth-play_3-0" % "12.0.0",
+  "com.gu" %% "pan-domain-auth-play_3-0" % "19.0.0",
   "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v2" % playSecretRotationVersion ,
   "com.gu.play-secret-rotation" %% "play-v30" % playSecretRotationVersion ,
   "com.gu.etag-caching" %% "aws-s3-sdk-v2" % "8.2.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Bumps panda auth version to fix vulnerability in "bouncy castle" crytopgraphy dependency. Running `sbt dependencyTree` shows it has been updated to the fixed `1.84` version.

See https://github.com/guardian/pan-domain-authentication/pull/257 and https://github.com/guardian/login.gutools/security/dependabot/32

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->

Tested by deploying to code and checking that I can still log in to https://gudocs.code.dev-gutools.co.uk/ in a private window.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Vulnerabilities 📉

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

Breaking auth, therefore test that this doesn't happen