### PR TITLE
Some security hardening

### DIFF
--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import com.github.nscala_time.time.Imports._
-import com.gu.pandomainauth.model.{AuthenticatedUser, CookieParseException, CookieSignatureInvalidException, User}
+import com.gu.pandomainauth.model.{AuthenticatedUser, User}
 import com.gu.pandomainauth.service.CookieUtils
 import com.gu.pandomainauth.{PanDomainAuthSettingsRefresher, PublicSettings}
 import play.api.mvc._
@@ -9,9 +9,10 @@ import services.NewCookieIssue
 import software.amazon.awssdk.services.ses.SesClient
 import utils._
 
+import java.security.SecureRandom
 import java.time.Instant.now
 import java.time.Duration
-import scala.util.Random
+import java.util.Base64
 import scala.util.control.NonFatal
 
 class Emergency(
@@ -60,10 +61,14 @@ class Emergency(
 
       val emailAddress = s"$emailPrefix@guardian.co.uk"
 
-      val token = Random.alphanumeric.take(20).mkString
+      val token = {
+        val byteArray = new Array[Byte](60)
+        SecureRandom.getInstanceStrong.nextBytes(byteArray)
+        // use UrlEncoder as this token will be transmitted in URL query params
+        Base64.getUrlEncoder.encodeToString(byteArray)
+      }
 
-      val cookieIssue = NewCookieIssue(token, emailAddress,
-        tokenIssuedAt, false)
+      val cookieIssue = NewCookieIssue(token, emailAddress, tokenIssuedAt, used = false)
 
       try {
         deps.tokenDBService.createCookieIssue(cookieIssue)

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -47,7 +47,7 @@ class Emergency(
     }
   }
 
-  def requestCookieLink: Action[AnyContent] = EmergencySwitchIsOnAction {
+  def requestCookieLink: Action[AnyContent] = EmergencySwitchIsOnAction { implicit request =>
     Ok(views.html.emergency.requestNewCookie(telemetryUrl))
   }
 

--- a/app/controllers/Emergency.scala
+++ b/app/controllers/Emergency.scala
@@ -23,6 +23,8 @@ class Emergency(
    telemetryUrl: String
 ) extends LoginController(deps, panDomainSettings) with Loggable {
 
+  private val secureRandom = SecureRandom.getInstance("NativePRNGNonBlocking")
+
   private val cookieLifetime = Duration.ofDays(1) // 1.day
 
   def reissueDisabled: Action[AnyContent] = Action {
@@ -63,7 +65,7 @@ class Emergency(
 
       val token = {
         val byteArray = new Array[Byte](60)
-        SecureRandom.getInstanceStrong.nextBytes(byteArray)
+        secureRandom.nextBytes(byteArray)
         // use UrlEncoder as this token will be transmitted in URL query params
         Base64.getUrlEncoder.encodeToString(byteArray)
       }

--- a/app/views/emergency/requestNewCookie.scala.html
+++ b/app/views/emergency/requestNewCookie.scala.html
@@ -1,4 +1,5 @@
-@(telemetryUrl: String)
+@import views.html.helper.CSRF
+@(telemetryUrl: String)(implicit request: RequestHeader)
 <html>
 <head>
     <title>
@@ -17,6 +18,7 @@
 
 <div>
   <form action="/emergency/send-cookie-link" method="post">
+      @CSRF.formField
       <div>
           <label for="email">Enter user email:</label>
           <input type="text" id="email" name="email"/><span>@@guardian.co.uk</span>

--- a/conf/routes
+++ b/conf/routes
@@ -20,7 +20,6 @@ GET     /emergency/reissue           controllers.Emergency.reissue()
 GET     /emergency/reissue-disabled  controllers.Emergency.reissueDisabled()
 GET     /emergency/request-cookie    controllers.Emergency.requestCookieLink()
 GET     /emergency/new-cookie/:token controllers.Emergency.issueNewCookie(token)
-+NOCSRF
 POST    /emergency/send-cookie-link  controllers.Emergency.sendCookieLink()
 
 GET     /switches                    controllers.SwitchesController.index()


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enables CSRF validation on the cookie request form submission, and strengthens the cookie request token (20 char alphanumeric token generated with the base `Random` generator -> 80 char base64 string, generated using the `SecureRandom` generator) 

## How has this change been tested?

Tested in CODE by turning on emergency mode and going through the flow to request a new cookie for myself.

